### PR TITLE
[FEATURE] Member Entity 생성 

### DIFF
--- a/src/main/java/org/lxdproject/lxd/domain/member/entity/Member.java
+++ b/src/main/java/org/lxdproject/lxd/domain/member/entity/Member.java
@@ -1,0 +1,83 @@
+package org.lxdproject.lxd.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.lxdproject.lxd.domain.member.enums.LoginType;
+import org.lxdproject.lxd.domain.member.enums.Role;
+import org.lxdproject.lxd.domain.member.enums.Status;
+import org.lxdproject.lxd.global.common.entity.BaseEntity;
+import org.lxdproject.lxd.global.common.enums.Language;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicUpdate
+@DynamicInsert
+public class Member extends BaseEntity {
+
+    // 고유번호
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    // 주사용언어
+    @Enumerated(EnumType.STRING)
+    @Column(name = "native_language", nullable = false)
+    private Language nativeLanguage;
+
+    // 학습언어
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Language language;
+
+    // 권한
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    // 아이디
+    @Column(nullable = false, length = 20)
+    private String username;
+
+    // 비밀번호
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String password;
+
+    // 이메일
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    // 닉네임
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    // 로그인 타입
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type", nullable = false)
+    private LoginType loginType;
+
+    // 개인정보 약관 동의 여부
+    @Column(name = "is_privacy_agreed", nullable = false)
+    private Boolean isPrivacyAgreed;
+
+    // 프로필 이미지 URL
+    @Column(name = "profile_img", columnDefinition = "TEXT")
+    private String profileImg;
+
+    // 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status = Status.ACTIVE;
+
+    // 알림 설정 여부
+    @Column(name = "is_alarm_agreed", nullable = false)
+    private Boolean isAlarmAgreed;
+
+}

--- a/src/main/java/org/lxdproject/lxd/domain/member/enums/LoginType.java
+++ b/src/main/java/org/lxdproject/lxd/domain/member/enums/LoginType.java
@@ -1,0 +1,6 @@
+package org.lxdproject.lxd.domain.member.enums;
+
+public enum LoginType {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/org/lxdproject/lxd/domain/member/enums/Role.java
+++ b/src/main/java/org/lxdproject/lxd/domain/member/enums/Role.java
@@ -1,0 +1,6 @@
+package org.lxdproject.lxd.domain.member.enums;
+
+public enum Role {
+    ADMIN,
+    USER,
+}

--- a/src/main/java/org/lxdproject/lxd/domain/member/enums/Status.java
+++ b/src/main/java/org/lxdproject/lxd/domain/member/enums/Status.java
@@ -1,0 +1,6 @@
+package org.lxdproject.lxd.domain.member.enums;
+
+public enum Status {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/org/lxdproject/lxd/global/common/entity/BaseEntity.java
+++ b/src/main/java/org/lxdproject/lxd/global/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package org.lxdproject.lxd.global.common.entity;
+
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/org/lxdproject/lxd/global/common/enums/Language.java
+++ b/src/main/java/org/lxdproject/lxd/global/common/enums/Language.java
@@ -1,0 +1,6 @@
+package org.lxdproject.lxd.global.common.enums;
+
+public enum Language {
+    KO,
+    ENG
+}


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #7 

## ✏️ Summary
- 공통 엔티티인 BaseEntity를 상속받아 생성/수정/삭제 일자를 관리합니다.
- 사용자 정보를 담는 Member Entity를 생성했습니다.
- 권한(Role), 언어(Language), 로그인 방식(LoginType), 상태(Status) 등은 enum으로 정의하여 적용했습니다.

## 📝 Changes
- BaseEntity 엔티티 생성
- Member 엔티티 생성
- Role, Language, LoginType, Status enum 생성 및 적용


## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 🙋‍♂️ 리뷰 요청

도메인 계층 기반으로 디렉토리 구조를 아래처럼 나눠봤어요.

- `domain/member`에 member 관련 파일들 정리
- `domain/global/common`에는 BaseEntity, 공통 enum 같은 공용 코드 넣었어요

이 구조가 괜찮은지, 혹시 개선할 점 있으면 편하게 말씀해주세요!

