### PR TITLE
[FEATURE] 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/MemberHandler.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/MemberHandler.java
@@ -1,0 +1,9 @@
+package org.lxdproject.lxd.apiPayload.code.exception.handler;
+
+import org.lxdproject.lxd.apiPayload.code.status.BaseErrorCode;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 준현 - MEMBER 에러 코드 (4300~4399)
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4301", "이미 존재하는 이메일입니다."),
     NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4302", "이미 존재하는 닉네임입니다."),
+    PRIVACY_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "MEMBER4303", "개인정보 동의는 필수입니다."),
 
     // 서현 - MEMBER 에러 코드 (4400~4499)
 

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -23,8 +23,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 정은 - MEMBER 에러 코드 (4200~4299)
 
     // 준현 - MEMBER 에러 코드 (4300~4399)
-    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4301", "이미 존재하는 이메일입니다."),
-    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4302", "이미 존재하는 닉네임입니다."),
+    EMAIL_DUPLICATION(HttpStatus.CONFLICT, "MEMBER4301", "이미 존재하는 이메일입니다."),
+    NICKNAME_DUPLICATION(HttpStatus.CONFLICT, "MEMBER4302", "이미 존재하는 닉네임입니다."),
     PRIVACY_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "MEMBER4303", "개인정보 동의는 필수입니다."),
 
     // 서현 - MEMBER 에러 코드 (4400~4499)

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,19 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 멤버 관련 에러
+    // 소윤 - MEMBER 에러 코드 (4000~4099)
+
+    // 민지 - MEMBER 에러 코드 (4100~4199)
+
+    // 정은 - MEMBER 에러 코드 (4200~4299)
+
+    // 준현 - MEMBER 에러 코드 (4300~4399)
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4301", "이미 존재하는 이메일입니다."),
+    NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "MEMBER4302", "이미 존재하는 닉네임입니다."),
+
+    // 서현 - MEMBER 에러 코드 (4400~4499)
+
     // 테스트 용 응답
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "PAGE400", "유효하지 않은 페이지 번호입니다."),
     TEST_FAIL(HttpStatus.BAD_REQUEST, "TEST400", "사용자 정의 실패 응답입니다.");

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
@@ -20,10 +20,10 @@ public class MemberRestController {
     private final MemberService memberService;
 
     @GetMapping("/join")
-    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
 
         Member member = memberService.join(joinRequestDTO);
-        ApiResponse.onSuccess(MemberConverter.toJoinResponseDTO(member));
+        return ApiResponse.onSuccess(MemberConverter.toJoinResponseDTO(member));
     }
 
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
@@ -1,5 +1,6 @@
 package org.lxdproject.lxd.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
@@ -19,7 +20,12 @@ public class MemberRestController {
 
     private final MemberService memberService;
 
-    @GetMapping("/join")
+    @PostMapping("/join")
+    @Operation(summary = "회원가입 api", description = "계정 생성", responses = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 실패, 파라미터 오류 등"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이메일, 닉네임 중복")
+    })
     public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
 
         Member member = memberService.join(joinRequestDTO);

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
@@ -2,11 +2,14 @@ package org.lxdproject.lxd.member.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.member.converter.MemberConverter;
+import org.lxdproject.lxd.member.dto.MemberRequestDTO;
+import org.lxdproject.lxd.member.dto.MemberResponseDTO;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.service.MemberService;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,7 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class MemberRestController {
 
+    private final MemberService memberService;
 
+    @GetMapping("/join")
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
 
+        Member member = memberService.join(joinRequestDTO);
+        ApiResponse.onSuccess(MemberConverter.toJoinResponseDTO(member));
+    }
 
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberRestController.java
@@ -1,0 +1,20 @@
+package org.lxdproject.lxd.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@Validated
+public class MemberRestController {
+
+
+
+
+}

--- a/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
+++ b/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
@@ -1,0 +1,21 @@
+package org.lxdproject.lxd.member.converter;
+
+import org.lxdproject.lxd.member.dto.MemberResponseDTO;
+import org.lxdproject.lxd.member.entity.Member;
+
+public class MemberConverter {
+
+    public static MemberResponseDTO.JoinResponseDTO toJoinResponseDTO(Member member) {
+        return MemberResponseDTO.JoinResponseDTO.builder()
+                .member(MemberResponseDTO.JoinResponseDTO.MemberDTO.builder()
+                        .memberId(member.getId())
+                        .email(member.getEmail())
+                        .username(member.getUsername())
+                        .nickname(member.getNickname())
+                        .profileImg(member.getProfileImg())
+                        .language(member.getLanguage().name())
+                        .build())
+                .build();
+    }
+
+}

--- a/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
+++ b/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
@@ -32,7 +32,7 @@ public class MemberConverter {
                 .email(joinRequestDTO.getEmail())
                 .nickname(joinRequestDTO.getNickname())
                 .loginType(LoginType.LOCAL)
-                .isPrivacyAgreed(Boolean.TRUE)
+                .isPrivacyAgreed(joinRequestDTO.getIsPrivacyAgreed())
                 .profileImg(joinRequestDTO.getProfileImg())
                 .status(Status.ACTIVE)
                 .isAlarmAgreed(Boolean.FALSE) // 알람은 꺼져있는게 Default

--- a/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
+++ b/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
@@ -1,7 +1,11 @@
 package org.lxdproject.lxd.member.converter;
 
+import org.lxdproject.lxd.member.dto.MemberRequestDTO;
 import org.lxdproject.lxd.member.dto.MemberResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.entity.enums.LoginType;
+import org.lxdproject.lxd.member.entity.enums.Role;
+import org.lxdproject.lxd.member.entity.enums.Status;
 
 public class MemberConverter {
 
@@ -16,6 +20,24 @@ public class MemberConverter {
                         .language(member.getLanguage().name())
                         .build())
                 .build();
+    }
+
+    public static Member toMember(MemberRequestDTO.JoinRequestDTO joinRequestDTO, String encryptedPassword) {
+        return Member.builder()
+                .nativeLanguage(joinRequestDTO.getNativeLanguage())
+                .language(joinRequestDTO.getLanguage())
+                .role(Role.USER)
+                .username(joinRequestDTO.getUsername())
+                .password(encryptedPassword)
+                .email(joinRequestDTO.getEmail())
+                .nickname(joinRequestDTO.getNickname())
+                .loginType(LoginType.LOCAL)
+                .isPrivacyAgreed(Boolean.TRUE)
+                .profileImg(joinRequestDTO.getProfileImg())
+                .status(Status.ACTIVE)
+                .isAlarmAgreed(Boolean.FALSE) // 알람은 꺼져있는게 Default
+                .build();
+
     }
 
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -27,6 +27,9 @@ public class MemberRequestDTO {
         @NotBlank(message = "비밀번호는 필수입니다.")
         String password;
 
+        @NotNull(message = "개인정보 수집 및 이용 동의는 필수입니다.")
+        private Boolean isPrivacyAgreed;
+
         @NotBlank(message = "아이디는 필수입니다.")
         @Size(max = 20, message = "아이디는 최대 20자까지 가능합니다.")
         String username;

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -1,4 +1,51 @@
 package org.lxdproject.lxd.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import org.lxdproject.lxd.diary.entity.enums.Language;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class MemberRequestDTO {
+
+    @Getter
+    @Schema(description = "회원가입을 위한 RequestDTO")
+    public static class JoinRequestDTO{
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식을 지켜야합니다.")
+        String email;
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password;
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(max = 20, message = "아이디는 최대 20자까지 가능합니다.")
+        String username;
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
+        String nickname;
+
+        String profileImg;
+
+        // 주사용언어
+        @NotNull(message = "주 사용언어는 필수입니다.")
+        @Schema(description = "사용 언어 (예: ENG, KO)")
+        private Language nativeLanguage;
+
+        // 학습언어
+        @NotNull(message = "학습언어는 필수입니다.")
+        @Schema(description = "사용 언어 (예: ENG, KO)")
+        private Language language;
+
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.member.dto;
+
+public class MemberRequestDTO {
+}

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.member.dto;
+
+public class MemberResponseDTO {
+}

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
@@ -1,4 +1,49 @@
 package org.lxdproject.lxd.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
 public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResponseDTO{
+
+        @Schema(description = "회원가입한 멤버 정보")
+        private MemberDTO member;
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class MemberDTO {
+            @Schema(description = "멤버 고유 번호")
+            private Long memberId;
+
+            @Schema(description = "이메일")
+            private String email;
+
+            @Schema(description = "아이디")
+            private String username;
+
+            @Schema(description = "닉네임")
+            private String nickname;
+
+            @Schema(description = "프로필 이미지 URL")
+            private String profileImg;
+
+            @Schema(description = "선택 언어 (KO, ENG 등)")
+            private String language;
+        }
+
+
+    }
+
 }

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.member.repository;
+
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -4,4 +4,7 @@ import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Boolean existsByEmail(String email);
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package org.lxdproject.lxd.member.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+}

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -2,10 +2,40 @@ package org.lxdproject.lxd.member.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.member.converter.MemberConverter;
+import org.lxdproject.lxd.member.dto.MemberRequestDTO;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    // private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public Member join(MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
+
+        System.out.print("email : " + joinRequestDTO.getEmail());
+
+        if(memberRepository.existsByEmail(joinRequestDTO.getEmail())) {
+            throw new MemberHandler(ErrorStatus.EMAIL_DUPLICATION);
+        }
+
+        if(memberRepository.existsByNickname(joinRequestDTO.getNickname())) {
+            throw new MemberHandler(ErrorStatus.NICKNAME_DUPLICATION);
+        }
+
+        // TODO Spring Security 의존성 추가 시, 해당 Encoder을 사용해서 비밀번호 암호화 하도록 변경하기
+        // Member member = MemberConverter.toMember(joinRequestDTO, bCryptPasswordEncoder.encode(joinRequestDTO.getPassword()));
+        Member member = MemberConverter.toMember(joinRequestDTO, "1234");
+
+        memberRepository.save(member);
+        return member;
+
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -20,7 +20,10 @@ public class MemberService {
 
     public Member join(MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
 
-        System.out.print("email : " + joinRequestDTO.getEmail());
+
+        if(!joinRequestDTO.getIsPrivacyAgreed().equals(Boolean.TRUE)){
+            throw new MemberHandler(ErrorStatus.PRIVACY_POLICY_NOT_AGREED);
+        }
 
         if(memberRepository.existsByEmail(joinRequestDTO.getEmail())) {
             throw new MemberHandler(ErrorStatus.EMAIL_DUPLICATION);


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #12 

## ✏️ Summary
회원가입 API를 구현하였습니다.
사용자 요청값의 유효성을 검증하고, 이메일 및 닉네임 중복을 검사하여 회원가입을 처리합니다.
또한, 아직 Spring Security 의존성을 추가하지 않은 상태이므로, 비밀번호는 암호화 없이 임시로 "1234"로 설정되며, 추후 로그인 기능과 함께 암호화를 적용할 예정입니다.

## 📝 Changes
- JoinRequestDTO, JoinResponseDTO 작성
- 유효성 검사 추가: @Valid, @NotBlank, @Email, @NotNull 등
- 개인정보 수집 및 이용 동의(isPrivacyAgreed) 값이 true인지 검증 로직 추가
- MemberService 내부 로직 구현
    - 이메일, 닉네임 중복 검사 (existsByEmail, existsByNickname)
    - MemberConverter를 이용한 DTO → Entity 매핑
    - 현재는 password를 "1234"로 고정 설정
- MemberHandler를 통한 도메인 예외 처리
- Swagger 문서 작성 (@Operation, @ApiResponse 등)

## 🔎 PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
