### PR TITLE
[FEATURE] 일기 CRD 구현(추후 세부 구현 필요)

### DIFF
--- a/src/main/java/org/lxdproject/lxd/LxdApplication.java
+++ b/src/main/java/org/lxdproject/lxd/LxdApplication.java
@@ -2,8 +2,11 @@ package org.lxdproject.lxd;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+
 public class LxdApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/DiaryHandler.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/DiaryHandler.java
@@ -1,0 +1,9 @@
+package org.lxdproject.lxd.apiPayload.code.exception.handler;
+
+import org.lxdproject.lxd.apiPayload.code.status.BaseErrorCode;
+
+public class DiaryHandler extends GeneralException {
+    public DiaryHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/MemberHandler.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/MemberHandler.java
@@ -1,0 +1,9 @@
+package org.lxdproject.lxd.apiPayload.code.exception.handler;
+
+import org.lxdproject.lxd.apiPayload.code.status.BaseErrorCode;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -17,7 +17,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 테스트 용 응답
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "PAGE400", "유효하지 않은 페이지 번호입니다."),
-    TEST_FAIL(HttpStatus.BAD_REQUEST, "TEST400", "사용자 정의 실패 응답입니다.");
+    TEST_FAIL(HttpStatus.BAD_REQUEST, "TEST400", "사용자 정의 실패 응답입니다."),
+
+    // 멤버 관련 에러 응답
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"MEMBER4001","존재하지 않는 회원입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 멤버 관련 에러 응답
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"MEMBER4001","존재하지 않는 회원입니다."),
+
+    // 일기 관련 에러 응답
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND,"DIARY4001","일기를 찾을 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -1,0 +1,27 @@
+package org.lxdproject.lxd.diary.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
+import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Diary API", description = "일기 관련 API 입니다.")
+@RequestMapping("/diaries")
+public interface DiaryApi {
+
+    @PostMapping
+    @Operation(summary = "일기 작성 API", description = "이미지는 s3업로드 api로 요청 후 전달된 url을 html content 안에 포함시켜서 저장 요청해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "회원 정보가 이상해요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<DiaryResponseDTO> createDiary(@RequestBody DiaryRequestDTO request);
+
+}

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -1,16 +1,17 @@
 package org.lxdproject.lxd.diary.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diary.dto.DiaryDetailResponseDTO;
 import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
 import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Diary API", description = "일기 관련 API 입니다.")
 @RequestMapping("/diaries")
@@ -24,4 +25,15 @@ public interface DiaryApi {
     })
     public ApiResponse<DiaryResponseDTO> createDiary(@RequestBody DiaryRequestDTO request);
 
+    @GetMapping("/{id}")
+    @Operation(summary = "일기 상세 조회 API", description = "id에 해당하는 일기를 상세 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "회원 정보가 이상해요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "없는 일기에요",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "id", description = "일기의 아이디, path variable 입니다!"),
+    })
+    public ApiResponse<DiaryDetailResponseDTO> getDiaryDetail(@PathVariable Long id);
 }

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -36,4 +36,12 @@ public interface DiaryApi {
             @Parameter(name = "id", description = "일기의 아이디, path variable 입니다!"),
     })
     public ApiResponse<DiaryDetailResponseDTO> getDiaryDetail(@PathVariable Long id);
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "일기 삭제 API", description = "id에 해당하는 일기를 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "없는 일기에요",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<Boolean> deleteDiary(@PathVariable Long id);
 }

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
@@ -2,9 +2,12 @@ package org.lxdproject.lxd.diary.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diary.dto.DiaryDetailResponseDTO;
 import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
 import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
 import org.lxdproject.lxd.diary.service.DiaryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,5 +20,10 @@ public class DiaryController implements DiaryApi{
     public ApiResponse<DiaryResponseDTO> createDiary(@RequestBody DiaryRequestDTO request) {
         DiaryResponseDTO response = diaryService.createDiary(request);
         return ApiResponse.onSuccess(response);
+    }
+
+    @Override
+    public ApiResponse<DiaryDetailResponseDTO> getDiaryDetail(@PathVariable Long id) {
+        return ApiResponse.onSuccess(diaryService.getDiaryDetail(id));
     }
 }

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
@@ -26,4 +26,10 @@ public class DiaryController implements DiaryApi{
     public ApiResponse<DiaryDetailResponseDTO> getDiaryDetail(@PathVariable Long id) {
         return ApiResponse.onSuccess(diaryService.getDiaryDetail(id));
     }
+
+    @Override
+    public ApiResponse<Boolean> deleteDiary(@PathVariable Long id) {
+        diaryService.deleteDiary(id);
+        return ApiResponse.onSuccess(Boolean.TRUE);
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
@@ -1,0 +1,21 @@
+package org.lxdproject.lxd.diary.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
+import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
+import org.lxdproject.lxd.diary.service.DiaryService;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DiaryController implements DiaryApi{
+    private final DiaryService diaryService;
+
+    @Override
+    public ApiResponse<DiaryResponseDTO> createDiary(@RequestBody DiaryRequestDTO request) {
+        DiaryResponseDTO response = diaryService.createDiary(request);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -1,0 +1,25 @@
+package org.lxdproject.lxd.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.lxdproject.lxd.diary.entity.enums.Language;
+import org.lxdproject.lxd.diary.entity.enums.Visibility;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class DiaryDetailResponseDTO {
+    private Long diaryId;
+    private Visibility visibility;
+    private String title;
+    private Language language;
+    private String profileImg;
+    private String writerNickName;
+    private String writerUserName;
+    private LocalDateTime createdAt;
+    private int commentCount;
+    private int likeCount;
+    private int correctCount;
+    private String content;
+}

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryRequestDTO.java
@@ -1,0 +1,20 @@
+package org.lxdproject.lxd.diary.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
+import org.lxdproject.lxd.diary.entity.enums.Language;
+import org.lxdproject.lxd.diary.entity.enums.Style;
+import org.lxdproject.lxd.diary.entity.enums.Visibility;
+
+@Getter @Setter
+public class DiaryRequestDTO {
+    private Long memberId; // 추후 인증 기반 처리 예정
+    private String title;
+    private String content;
+    private Style style;
+    private Visibility visibility;
+    private CommentPermission commentPermission;
+    private Language language;
+    private String thumbImg;
+}

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryResponseDTO.java
@@ -1,0 +1,11 @@
+package org.lxdproject.lxd.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DiaryResponseDTO {
+    private Long diaryId;
+    private String thumbnailUrl;
+}

--- a/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
+++ b/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import jakarta.persistence.Id;
 
+import org.lxdproject.lxd.common.entity.BaseEntity;
 import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Style;
@@ -19,7 +20,7 @@ import org.lxdproject.lxd.member.entity.Member;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Diary{
+public class Diary extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
+++ b/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
@@ -11,6 +11,7 @@ import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Style;
 import org.lxdproject.lxd.diary.entity.enums.Visibility;
+import org.lxdproject.lxd.member.entity.Member;
 
 @Table(name = "일기")
 @Entity
@@ -18,15 +19,15 @@ import org.lxdproject.lxd.diary.entity.enums.Visibility;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Diary {
+public class Diary{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "member_id")
-//    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "member_id", nullable = true)
+    private Member member;
 
     private String title;
 
@@ -45,11 +46,14 @@ public class Diary {
     @Enumerated(EnumType.STRING)
     private Language language;
 
-    private Integer likeCount;
+    @Builder.Default
+    private Integer likeCount=0;
 
-    private Integer commentCount;
+    @Builder.Default
+    private Integer commentCount=0;
 
-    private Integer correctionCount;
+    @Builder.Default
+    private Integer correctionCount=0;
 
     @Column(columnDefinition = "TEXT")
     private String thumbImg;

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.diary.repository;
+
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -76,4 +76,14 @@ public class DiaryService {
         );
     }
 
+    @Transactional
+    public void deleteDiary(Long diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+        // Todo: JWT 토큰에서 추출해서 삭제 권한을 검사
+        // Todo: S3 이미지 삭제 로직 구현
+
+        diaryRepository.delete(diary);
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -1,0 +1,45 @@
+package org.lxdproject.lxd.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
+import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.repository.DiaryRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+
+    public DiaryResponseDTO createDiary(DiaryRequestDTO request) {
+        Member member = null;
+
+//        if (request.getMemberId() != null) {
+//            member = memberRepository.findById(request.getMemberId())
+//                    .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+//        }
+
+        Diary diary = Diary.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .style(request.getStyle())
+                .visibility(request.getVisibility())
+                .commentPermission(request.getCommentPermission())
+                .language(request.getLanguage())
+                .thumbImg(request.getThumbImg())
+                .member(member)
+                .build();
+
+        diaryRepository.save(diary);
+
+        return new DiaryResponseDTO(
+                diary.getId(),
+                diary.getThumbImg()
+        );
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -1,6 +1,10 @@
 package org.lxdproject.lxd.diary.service;
 
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.diary.dto.DiaryDetailResponseDTO;
 import org.lxdproject.lxd.diary.dto.DiaryRequestDTO;
 import org.lxdproject.lxd.diary.dto.DiaryResponseDTO;
 import org.lxdproject.lxd.diary.entity.Diary;
@@ -8,6 +12,7 @@ import org.lxdproject.lxd.diary.repository.DiaryRepository;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,12 +22,14 @@ public class DiaryService {
     private final MemberRepository memberRepository;
 
     public DiaryResponseDTO createDiary(DiaryRequestDTO request) {
+
+        // Todo: 현재 로그인한 사용자의 고유번호 넣기
         Member member = null;
 
-//        if (request.getMemberId() != null) {
-//            member = memberRepository.findById(request.getMemberId())
-//                    .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//        }
+        if (request.getMemberId() != null) {
+            member = memberRepository.findById(request.getMemberId())
+                    .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
 
         Diary diary = Diary.builder()
                 .title(request.getTitle())
@@ -42,4 +49,31 @@ public class DiaryService {
                 diary.getThumbImg()
         );
     }
+
+    @Transactional(readOnly = true)
+    public DiaryDetailResponseDTO getDiaryDetail(Long id) {
+        Diary diary = diaryRepository.findById(id)
+                .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+        Member member = diary.getMember();
+        if (member == null) {
+            throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+
+        return new DiaryDetailResponseDTO(
+                diary.getId(),
+                diary.getVisibility(),
+                diary.getTitle(),
+                diary.getLanguage(),
+                member.getProfileImg(),
+                member.getNickname(),
+                member.getUsername(),
+                diary.getCreatedAt(),
+                diary.getCommentCount(),
+                diary.getLikeCount(),
+                diary.getCorrectionCount(),
+                diary.getContent()
+        );
+    }
+
 }

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.member.repository;
+
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
related #17 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
### 이미지를 포함한 일기 작성 전체 흐름
1. 사용자가 에디터에서 이미지를 업로드하면 이미지가 S3에 저장되고 URL이 프론트로 전달됨
2. 프론트는 해당 URL을 `<img>` 태그로 HTML content 안에 포함시켜 백엔드로 일기 저장 요청을 보냄
3. 백엔드는 `content`만 저장함. (이미지 URL은 HTML 안에 포함된 상태)
4. 일기를 삭제할 때는, HTML content 안에 포함된 S3 이미지들도 함께 삭제해야 함

### 일기 삭제 시 S3 이미지 삭제

> 일기당 이미지 최대 5개 제한
이미지 URL은 HTML content 안에 포함
👉 이미지 URL을 따로 저장해서 관리하는 것보다 HTML 파서로 이미지 URL을 추출해서 S3에서 삭제하는 방식이 더 효율적임

1. 일기 삭제 전 content(html) 안에서 S3 URL들을 파싱
2. S3에 해당 이미지 key로 삭제 요청을 보냄
3. DB에서 일기를 삭제


## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
member, s3이미지 도메인 연결 후 세부 구현 필요함
- JWT 토큰에서 추출해서 삭제 권한을 검사
- S3 이미지 삭제 로직 구현

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
