### PR TITLE
[FEATURE] 교정 생성 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/CorrectionHandler.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/CorrectionHandler.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.apiPayload.code.exception.handler;
+
+public class CorrectionHandler {
+}

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -37,6 +37,6 @@ public class CorrectionRestController {
             @RequestBody @Valid CorrectionRequestDTO.CreateRequestDTO requestDto,
             @AuthenticationPrincipal Member member
     ) {
-        return ApiResponse.onSuccess( correctionService.createCorrection(requestDto, member));
+        return ApiResponse.onSuccess(correctionService.createCorrection(requestDto, member));
     }
 }

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -1,0 +1,42 @@
+package org.lxdproject.lxd.correction.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
+import org.lxdproject.lxd.correction.service.CorrectionService;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/corrections")
+@Validated
+public class CorrectionRestController {
+    private final CorrectionService correctionService;
+
+    @PostMapping
+    @Operation(
+            summary = "교정 등록 API",
+            description = "일기의 문장에서 특정 부분을 교정하고 피드백 코멘트를 작성하여 등록합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "교정 등록 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 형식 또는 유효성 실패"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 접근"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID")
+            }
+    )
+    public ApiResponse<CorrectionResponseDTO.CreateResponseDTO> createCorrection(
+            @RequestBody @Valid CorrectionRequestDTO.CreateRequestDTO requestDto,
+            @AuthenticationPrincipal Member member
+    ) {
+        return ApiResponse.onSuccess( correctionService.createCorrection(requestDto, member));
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionRequestDTO.java
@@ -1,0 +1,28 @@
+package org.lxdproject.lxd.correction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CorrectionRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "교정 등록 요청 DTO")
+    public static class CreateRequestDTO {
+
+        @Schema(description = "대상 일기 ID", example = "42")
+        private Long diaryId;
+
+        @Schema(description = "원본 문장", example = "오늘은 피자날입니다.")
+        private String original;
+
+        @Schema(description = "교정한 내용", example = "피자 먹는날")
+        private String corrected;
+
+        @Schema(description = "피드백 코멘트", example = "‘피자날’보다는 ‘피자 먹는날’이 자연스럽습니다.")
+        private String commentText;
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionRequestDTO.java
@@ -1,6 +1,8 @@
 package org.lxdproject.lxd.correction.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,13 +15,16 @@ public class CorrectionRequestDTO {
     @Schema(description = "교정 등록 요청 DTO")
     public static class CreateRequestDTO {
 
+        @NotNull(message = "diaryId는 필수입니다.")
         @Schema(description = "대상 일기 ID", example = "42")
         private Long diaryId;
 
+        @NotBlank(message = "원본 문장은 비어 있을 수 없습니다.")
         @Schema(description = "원본 문장", example = "오늘은 피자날입니다.")
         private String original;
 
-        @Schema(description = "교정한 내용", example = "피자 먹는날")
+        @NotBlank(message = "교정 내용은 비어 있을 수 없습니다.")
+        @Schema(description = "교정한 내용", example = "오늘은 피자 먹는날")
         private String corrected;
 
         @Schema(description = "피드백 코멘트", example = "‘피자날’보다는 ‘피자 먹는날’이 자연스럽습니다.")

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -1,0 +1,31 @@
+package org.lxdproject.lxd.correction.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class CorrectionResponseDTO {
+
+    @Getter
+    @Builder
+    public static class CreateResponseDTO {
+        private Long correctionId;
+        private Long diaryId;
+        private String createdAt;
+        private AuthorDTO author;
+        private String original;
+        private String corrected;
+        private String commentText;
+        private int likeCount;
+        private int commentCount;
+        private boolean isLikedByMe;
+    }
+
+    @Getter
+    @Builder
+    public static class AuthorDTO {
+        private Long memberId;
+        private String userId;
+        private String nickname;
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/entity/Correction.java
+++ b/src/main/java/org/lxdproject/lxd/correction/entity/Correction.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.lxdproject.lxd.common.entity.BaseEntity;
 import org.lxdproject.lxd.correction.entity.mapping.MemberSavedCorrection;
 import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.member.entity.Member;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Correction {
+public class Correction extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,13 +28,15 @@ public class Correction {
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "author_id", nullable = false)
-//    private Member author;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private Member author;
 
-    // 교정 부분 내용 (html 포함)
-    @Column(name = "content_html", columnDefinition = "TEXT", nullable = false)
-    private String contentHtml;
+    @Column(name = "original_text", nullable = false)
+    private String originalText;
+
+    @Column(name = "corrected", length = 300, nullable = false)
+    private String corrected;
 
     // 교정에 대한 코멘트 내용
     @Column(name = "comment_text", length = 500)

--- a/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
+++ b/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.correction.entity.mapping;
 import jakarta.persistence.*;
 import lombok.*;
 import org.lxdproject.lxd.correction.entity.Correction;
+import org.lxdproject.lxd.member.entity.Member;
 
 @Entity
 @Getter
@@ -19,9 +20,9 @@ public class MemberSavedCorrection {
     @JoinColumn(name = "correction_id", nullable = false)
     private Correction correction;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "member_id", nullable = false)
-//    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "memo")
     private String memo;

--- a/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.correction.repository;
+
+import org.lxdproject.lxd.correction.entity.Correction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CorrectionRepository extends JpaRepository<Correction, Long> {
+}

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -2,6 +2,8 @@ package org.lxdproject.lxd.correction.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
 import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
 import org.lxdproject.lxd.correction.entity.Correction;
@@ -27,7 +29,7 @@ public class CorrectionService {
             Member author
     ) {
         Diary diary = diaryRepository.findById(requestDto.getDiaryId())
-                .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다. ID: " + requestDto.getDiaryId()));
+                .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
         Correction correction = Correction.builder()
                 .diary(diary)

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -1,0 +1,62 @@
+package org.lxdproject.lxd.correction.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
+import org.lxdproject.lxd.correction.entity.Correction;
+import org.lxdproject.lxd.correction.repository.CorrectionRepository;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.repository.DiaryRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class CorrectionService {
+
+    private final CorrectionRepository correctionRepository;
+    private final DiaryRepository diaryRepository;
+
+    @Transactional
+    public CorrectionResponseDTO.CreateResponseDTO createCorrection(
+            CorrectionRequestDTO.CreateRequestDTO requestDto,
+            Member author
+    ) {
+        Diary diary = diaryRepository.findById(requestDto.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다. ID: " + requestDto.getDiaryId()));
+
+        Correction correction = Correction.builder()
+                .diary(diary)
+                .author(author)
+                .originalText(requestDto.getOriginal())
+                .corrected(requestDto.getCorrected())
+                .commentText(requestDto.getCommentText())
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+
+        Correction saved = correctionRepository.save(correction);
+
+        return CorrectionResponseDTO.CreateResponseDTO.builder()
+                .correctionId(saved.getId())
+                .diaryId(saved.getDiary().getId())
+                .createdAt(saved.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy. MM. dd a hh:mm:ss").withLocale(Locale.KOREA)))
+                .original(saved.getOriginalText())
+                .corrected(saved.getCorrected())
+                .commentText(saved.getCommentText())
+                .likeCount(saved.getLikeCount())
+                .commentCount(saved.getCommentCount())
+                .isLikedByMe(false)
+                .author(CorrectionResponseDTO.AuthorDTO.builder()
+                        .memberId(author.getId())
+                        .userId(author.getUsername())
+                        .nickname(author.getNickname())
+                        .profileImageUrl(author.getProfileImg())
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #15 

## ✏️ Summary
- 교정(Correction) 기능 생성 API를 구현했습니다.
- 일기(Diary)에 대해 사용자가 문장을 교정하고 피드백을 남길 수 있습니다.

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
- `Correction` 엔티티 변동사항
    - **`originalText` 필드 추가**
        - 원래 없던 필드 → 새로 추가됨
        - 교정 전 원본 문장 저장 목적
    - `correctionTarget` → `corrected`로 컬럼명 변경
        - 교정된 문장 전체를 저장하는 목적

---

- `Correction` Entity 생성 및 Diary, Member와의 연관관계 설정
- `MemberSavedCorrection` Entity 연관관계 설정
- DTO (`CorrectionRequestDTO`, `CorrectionResponseDTO`) 구성
- `CorrectionRestController`에서 POST 등록 API 구현
- 예외 처리: 존재하지 않는 일기 예외 (`DIARY_NOT_FOUND`) 적용



## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
