### PR TITLE
[FEATURE] 내가 작성한 교정 조회 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
@@ -1,0 +1,52 @@
+package org.lxdproject.lxd.correction.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Correction API", description = "교정 관련 API입니다.")
+@RequestMapping("/corrections")
+public interface CorrectionApi {
+
+    @Operation(
+            summary = "교정 등록 API",
+            description = "일기의 문장에서 특정 부분을 교정하고 피드백 코멘트를 작성하여 등록합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "교정 등록 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 형식 또는 유효성 실패"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 접근"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID")
+            }
+    )
+    @PostMapping
+    ApiResponse<CorrectionResponseDTO.CreateResponseDTO> createCorrection(
+            @RequestBody @Valid CorrectionRequestDTO.CreateRequestDTO requestDto,
+            @AuthenticationPrincipal Member member
+    );
+
+    @Operation(
+            summary = "내가 제공한 교정 목록 조회",
+            description = "현재 로그인한 사용자가 다른 사람의 일기에 작성한 교정 리스트를 반환합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+            }
+    )
+    @GetMapping("/provided")
+    ApiResponse<CorrectionResponseDTO.ProvidedCorrectionsResponseDTO> getMyProvidedCorrections(
+            @AuthenticationPrincipal Member member,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지에 포함할 교정 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    );
+}

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -1,42 +1,34 @@
 package org.lxdproject.lxd.correction.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
 import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
 import org.lxdproject.lxd.correction.service.CorrectionService;
 import org.lxdproject.lxd.member.entity.Member;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/corrections")
 @Validated
-public class CorrectionRestController {
+public class CorrectionRestController implements CorrectionApi {
+
     private final CorrectionService correctionService;
 
-    @PostMapping
-    @Operation(
-            summary = "교정 등록 API",
-            description = "일기의 문장에서 특정 부분을 교정하고 피드백 코멘트를 작성하여 등록합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "교정 등록 성공"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 형식 또는 유효성 실패"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 접근"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID")
-            }
-    )
+    @Override
     public ApiResponse<CorrectionResponseDTO.CreateResponseDTO> createCorrection(
-            @RequestBody @Valid CorrectionRequestDTO.CreateRequestDTO requestDto,
-            @AuthenticationPrincipal Member member
+            CorrectionRequestDTO.CreateRequestDTO requestDto,
+            Member member
     ) {
         return ApiResponse.onSuccess(correctionService.createCorrection(requestDto, member));
+    }
+
+    @Override
+    public ApiResponse<CorrectionResponseDTO.ProvidedCorrectionsResponseDTO> getMyProvidedCorrections(
+            Member member, int page, int size
+    ) {
+        return ApiResponse.onSuccess(correctionService.getMyProvidedCorrections(member, page, size));
     }
 }

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -3,6 +3,8 @@ package org.lxdproject.lxd.correction.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 public class CorrectionResponseDTO {
 
     @Getter
@@ -27,5 +29,29 @@ public class CorrectionResponseDTO {
         private String userId;
         private String nickname;
         private String profileImageUrl;
+    }
+
+    @Getter
+    @Builder
+    public static class CorrectionItem {
+        private Long correctionId;
+        private Long diaryId;
+        private String diaryTitle;
+        private String diaryCreatedAt;
+        private String createdAt;
+        private String original;
+        private String corrected;
+        private String commentText;
+    }
+
+    @Getter
+    @Builder
+    public static class ProvidedCorrectionsResponseDTO {
+        private AuthorDTO member;
+        private List<CorrectionItem> corrections;
+        private int page;
+        private int size;
+        private int totalCount;
+        private boolean hasNext;
     }
 }

--- a/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
@@ -1,7 +1,11 @@
 package org.lxdproject.lxd.correction.repository;
 
 import org.lxdproject.lxd.correction.entity.Correction;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
+    Page<Correction> findByAuthor(Member author, Pageable pageable);
 }

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -1,5 +1,9 @@
 package org.lxdproject.lxd.correction.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
@@ -13,7 +17,9 @@ import org.lxdproject.lxd.diary.repository.DiaryRepository;
 import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Locale;
 
 @Service
@@ -46,7 +52,7 @@ public class CorrectionService {
         return CorrectionResponseDTO.CreateResponseDTO.builder()
                 .correctionId(saved.getId())
                 .diaryId(saved.getDiary().getId())
-                .createdAt(saved.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy. MM. dd a hh:mm:ss").withLocale(Locale.KOREA)))
+                .createdAt(formatDate(saved.getCreatedAt()))
                 .original(saved.getOriginalText())
                 .corrected(saved.getCorrected())
                 .commentText(saved.getCommentText())
@@ -60,5 +66,43 @@ public class CorrectionService {
                         .profileImageUrl(author.getProfileImg())
                         .build())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public CorrectionResponseDTO.ProvidedCorrectionsResponseDTO getMyProvidedCorrections(Member member, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Correction> corrections = correctionRepository.findByAuthor(member, pageable);
+
+        List<CorrectionResponseDTO.CorrectionItem> correctionItems = corrections.getContent().stream()
+                .map(correction -> CorrectionResponseDTO.CorrectionItem.builder()
+                        .correctionId(correction.getId())
+                        .diaryId(correction.getDiary().getId())
+                        .diaryTitle(correction.getDiary().getTitle())
+                        .diaryCreatedAt(formatDate(correction.getDiary().getCreatedAt()))
+                        .createdAt(formatDate(correction.getCreatedAt()))
+                        .original(correction.getOriginalText())
+                        .corrected(correction.getCorrected())
+                        .commentText(correction.getCommentText())
+                        .build())
+                .toList();
+
+        return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
+                .member(CorrectionResponseDTO.AuthorDTO.builder()
+                        .memberId(member.getId())
+                        .userId(member.getUsername())
+                        .nickname(member.getNickname())
+                        .profileImageUrl(member.getProfileImg())
+                        .build())
+                .corrections(correctionItems)
+                .page(page)
+                .size(size)
+                .totalCount((int) corrections.getTotalElements())
+                .hasNext(corrections.hasNext())
+                .build();
+    }
+
+    private String formatDate(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy. MM. dd a hh:mm", Locale.KOREA));
     }
 }


### PR DESCRIPTION
## 📌 Issue number and Link
closed #34 

## ✏️ Summary
내가 제공한 교정 목록 조회 API 구현합니다.

## 📝 Changes
- `/corrections/provided` GET API 구현
    - 사용자가 **다른 사람의 일기에 작성한 교정 목록**을 페이지네이션으로 조회
- `RestController`내 Swagger 어노테이션을 `CorrectionApi` **interface로 분리**

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
