### PR TITLE
[FEATURE] 일기 댓글 작성 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.diarycomment.controller;
+
+public class DiaryCommentApi {
+}

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
@@ -1,0 +1,40 @@
+package org.lxdproject.lxd.diarycomment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diarycomment.dto.DiaryCommentRequestDTO;
+import org.lxdproject.lxd.diarycomment.dto.DiaryCommentResponseDTO;
+import org.lxdproject.lxd.diarycomment.service.DiaryCommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Diary Comment", description = "일기 댓글 관련 API")
+@RestController
+@RequestMapping("/diaries/{diaryId}/comments")
+@RequiredArgsConstructor
+public class DiaryCommentController {
+
+    private final DiaryCommentService diaryCommentService;
+
+    @Operation(
+            summary = "댓글 작성",
+            description = "특정 일기에 댓글을 작성합니다.",
+            security = @SecurityRequirement(name = "BearerAuth") // Swagger용 인증 명시
+    )
+    @PostMapping
+    public ResponseEntity<DiaryCommentResponseDTO> writeComment(
+            @PathVariable Long diaryId,
+            @RequestBody DiaryCommentRequestDTO request,
+            @AuthenticationPrincipal(expression = "username") String userIdStr // userId 추출
+    ) {
+        Long userId = Long.parseLong(userIdStr);
+        DiaryCommentResponseDTO response = diaryCommentService.writeComment(userId, diaryId, request);
+        return ResponseEntity.ok(response);
+    }
+}
+
+
+

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentRequestDTO.java
@@ -1,0 +1,10 @@
+package org.lxdproject.lxd.diarycomment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DiaryCommentRequestDTO {
+    private String commentText;
+    private Long parentId; // null이면 일반 댓글
+}
+

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -1,0 +1,18 @@
+package org.lxdproject.lxd.diarycomment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DiaryCommentResponseDTO {
+    private Long id;
+    private Long userId;
+    private Long diaryId;
+    private String commentText;
+    private Long parentId;
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/org/lxdproject/lxd/diarycomment/entity/DiaryComment.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/entity/DiaryComment.java
@@ -26,6 +26,16 @@ public class DiaryComment extends BaseEntity {
     private Long parentId; // 일반 댓글이면 null
 
     private int likeCount;
+
+    // DiaryComment.java (Entity)
+    public void increaseLikeCount() {
+        this.likeCount += 1;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount = Math.max(this.likeCount - 1, 0); // 음수 방지
+    }
+
 }
 
 

--- a/src/main/java/org/lxdproject/lxd/diarycomment/entity/DiaryComment.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/entity/DiaryComment.java
@@ -1,0 +1,32 @@
+package org.lxdproject.lxd.diarycomment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.lxdproject.lxd.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "diary_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DiaryComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long diaryId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String commentText;
+
+    private Long parentId; // 일반 댓글이면 null
+
+    private int likeCount;
+}
+
+
+

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -1,0 +1,8 @@
+package org.lxdproject.lxd.diarycomment.repository;
+
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long> {
+}
+

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -1,0 +1,37 @@
+package org.lxdproject.lxd.diarycomment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diarycomment.dto.DiaryCommentRequestDTO;
+import org.lxdproject.lxd.diarycomment.dto.DiaryCommentResponseDTO;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryCommentService {
+
+    private final DiaryCommentRepository diaryCommentRepository;
+
+    public DiaryCommentResponseDTO writeComment(Long userId, Long diaryId, DiaryCommentRequestDTO request) {
+        DiaryComment comment = DiaryComment.builder()
+                .userId(userId)
+                .diaryId(diaryId)
+                .commentText(request.getCommentText())
+                .parentId(request.getParentId())
+                .likeCount(0)
+                .build();
+
+        DiaryComment saved = diaryCommentRepository.save(comment);
+
+        return DiaryCommentResponseDTO.builder()
+                .id(saved.getId())
+                .userId(saved.getUserId())
+                .diaryId(saved.getDiaryId())
+                .commentText(saved.getCommentText())
+                .parentId(saved.getParentId())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #35 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기 상세 페이지에서 댓글을 작성하는 기능을 구현했습니다.
해당 API는 JWT 인증이 필요한 POST 요청이며, Swagger에 보안 설정(BearerAuth)도 적용되어 있습니다.
commentText, parentId를 받아 일반 댓글과 대댓글 모두 작성할 수 있습니다.

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
DiaryComment Entity 생성 및 BaseEntity 상속

댓글 작성용 Request/Response DTO 구현

Repository, Service, Controller 레이어 구조 구성

@AuthenticationPrincipal을 통해 JWT 토큰에서 userId 추출

Swagger 보안 설정 주석 추가 및 인증 테스트 가능하게 적용


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 일기 댓글 작성 기능이 추가되었습니다. 사용자는 특정 일기에 댓글을 작성할 수 있습니다.
  * 댓글은 대댓글(답글) 형태로도 작성할 수 있습니다.
  * 댓글 작성 시, 댓글 내용과 상위 댓글(선택 사항)을 입력할 수 있습니다.
  * 댓글 작성 결과로 댓글 정보(작성자, 일기 ID, 내용, 생성 시각 등)를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->