### PR TITLE
feat: 일기 댓글 좋아요 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/controller/DiaryCommentLikeApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/controller/DiaryCommentLikeApi.java
@@ -1,0 +1,34 @@
+package org.lxdproject.lxd.diarycommentlike.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.lxdproject.lxd.diarycommentlike.dto.DiaryCommentLikeResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "DiaryCommentLike", description = "일기 댓글 좋아요 API")
+public interface DiaryCommentLikeApi {
+
+    @Operation(
+            summary = "댓글 좋아요 토글",
+            description = "일기 댓글에 대해 좋아요 또는 좋아요 취소를 토글합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "요청 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음"),
+            }
+    )
+    @PostMapping("/diaries/{diaryId}/comments/{commentId}/likes")
+    ResponseEntity<DiaryCommentLikeResponseDTO> toggleCommentLike(
+            @Parameter(description = "일기 ID", example = "1")
+            @PathVariable Long diaryId,
+
+            @Parameter(description = "댓글 ID", example = "15")
+            @PathVariable Long commentId
+    );
+}

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/controller/DiaryCommentLikeController.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/controller/DiaryCommentLikeController.java
@@ -1,0 +1,26 @@
+package org.lxdproject.lxd.diarycommentlike.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diarycommentlike.dto.DiaryCommentLikeResponseDTO;
+import org.lxdproject.lxd.diarycommentlike.service.DiaryCommentLikeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diaries/{diaryId}/comments/{commentId}/likes")
+public class DiaryCommentLikeController {
+
+    private final DiaryCommentLikeService diaryCommentLikeService;
+
+    @PostMapping
+    public ResponseEntity<DiaryCommentLikeResponseDTO> toggleLike(
+            @PathVariable Long diaryId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal(expression = "username") String memberIdStr
+    ) {
+        Long memberId = Long.parseLong(memberIdStr);
+        return ResponseEntity.ok(diaryCommentLikeService.toggleLike(memberId, diaryId, commentId));
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeRequestDTO.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.diarycommentlike.dto;
+
+public class DiaryCommentLikeRequestDTO {
+}

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeResponseDTO.java
@@ -1,0 +1,13 @@
+package org.lxdproject.lxd.diarycommentlike.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DiaryCommentLikeResponseDTO {
+    private Long commentId;
+    private Long memberId;
+    private boolean liked;
+    private int likeCount;
+}

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/entity/DiaryCommentLike.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/entity/DiaryCommentLike.java
@@ -1,0 +1,28 @@
+package org.lxdproject.lxd.diarycommentlike.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.lxdproject.lxd.common.entity.BaseEntity;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+
+@Entity
+@Table(name = "diary_comment_like",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "comment_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DiaryCommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private DiaryComment comment;
+}
+

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
@@ -1,0 +1,10 @@
+package org.lxdproject.lxd.diarycommentlike.repository;
+
+import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DiaryCommentLikeRepository extends JpaRepository<DiaryCommentLike, Long> {
+    Optional<DiaryCommentLike> findByMemberIdAndComment_Id(Long memberId, Long commentId);
+}

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
@@ -1,0 +1,53 @@
+package org.lxdproject.lxd.diarycommentlike.service;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
+import org.lxdproject.lxd.diarycommentlike.dto.DiaryCommentLikeResponseDTO;
+import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
+import org.lxdproject.lxd.diarycommentlike.repository.DiaryCommentLikeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryCommentLikeService {
+
+    private final DiaryCommentLikeRepository likeRepository;
+    private final DiaryCommentRepository commentRepository;
+
+    public DiaryCommentLikeResponseDTO toggleLike(Long memberId, Long diaryId, Long commentId) {
+
+        DiaryComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+        if (!comment.getDiaryId().equals(diaryId)) {
+            throw new IllegalArgumentException("해당 댓글은 지정된 일기에 속하지 않습니다.");
+        }
+
+        Optional<DiaryCommentLike> existing = likeRepository.findByMemberIdAndComment_Id(memberId, commentId);
+        boolean liked;
+
+        if (existing.isPresent()) {
+            likeRepository.delete(existing.get());
+            comment.decreaseLikeCount(); // likeCount 감소
+            liked = false;
+        } else {
+            likeRepository.save(DiaryCommentLike.builder()
+                    .memberId(memberId)
+                    .comment(comment)
+                    .build());
+            comment.increaseLikeCount(); // likeCount 증가
+            liked = true;
+        }
+
+        return DiaryCommentLikeResponseDTO.builder()
+                .commentId(commentId)
+                .memberId(memberId)
+                .liked(liked)
+                .likeCount(comment.getLikeCount())
+                .build();
+    }
+}
+


### PR DESCRIPTION
-DiaryCommentLike 엔티티 및 Repository 추가
-댓글 좋아요 토클 기능 서비스 메서드 구현
-Swagger테스트용 Controller 작성

## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #40 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기의 댓글에 좋아요 누르기 API를 작성했습니다.

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
-DiaryCommentLike Entity추가
- /diaries/{diaryId}/comments/{commentId}/likes 엔드포인트 구현
- 중복 좋아요 방지를 위해 기존 좋아요 여부 확인 후 처리
- Swagger 테스트 컨트롤러(DiaryCommentLikeApi) 포함


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
