### PR TITLE
[REFACTOR] 일기 삭제 세부구현 완료

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND,"DIARY4001","일기를 찾을 수 없습니다."),
+    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST,"DIARY4002","이미지는 최대 5개까지만 첨부할 수 있습니다."),
 
     // 메일 관련 에러
     UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL 4301", "이메일을 보낼 수 없습니다."),

--- a/src/main/java/org/lxdproject/lxd/common/util/S3Uploader.java
+++ b/src/main/java/org/lxdproject/lxd/common/util/S3Uploader.java
@@ -6,11 +6,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -41,5 +48,50 @@ public class S3Uploader {
     private String getFileUrl(String fileName) {
         return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
     }
+
+    public List<String> extractS3KeysFromUrls(List<String> imageUrls) {
+        return imageUrls.stream()
+                .map(this::extractKeyFromUrl)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private String extractKeyFromUrl(String url) {
+        try {
+            URI uri = new URI(url);
+            return uri.getPath().substring(1); // /diary/abc.jpg → diary/abc.jpg
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    public void deleteFiles(List<String> keys) {
+        if (keys.isEmpty()) return;
+
+        List<ObjectIdentifier> objectsToDelete = keys.stream()
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .toList();
+
+        Delete delete = Delete.builder()
+                .objects(objectsToDelete)
+                .build();
+
+        DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+                .bucket(bucket)
+                .delete(delete)
+                .build();
+
+        try {
+            DeleteObjectsResponse response = s3Client.deleteObjects(request);
+            if (!response.hasErrors()) {
+                log.info("모든 S3 이미지 삭제 성공");
+            } else {
+                log.warn("일부 S3 이미지 삭제 실패: {}", response.errors());
+            }
+        } catch (S3Exception e) {
+            log.warn("S3 이미지 삭제 중 예외 발생: {}", e.awsErrorDetails().errorMessage());
+        }
+    }
+
 }
 

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -30,7 +30,6 @@ public interface DiaryApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 필요 (JWT 누락 또는 만료)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
-    @PreAuthorize("isAuthenticated()")
     public ApiResponse<DiaryDetailResponseDTO> createDiary( @Valid @RequestBody DiaryRequestDTO request);
 
     @GetMapping("/{id}")

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -47,7 +47,7 @@ public interface DiaryApi {
     public ApiResponse<DiaryDetailResponseDTO> getDiaryDetail(@PathVariable Long id);
 
     @DeleteMapping("/{id}")
-    @Operation(summary = "일기 삭제 API", description = "id에 해당하는 일기를 삭제합니다.")
+    @Operation(summary = "일기 삭제 API", description = "id에 해당하는 일기를 삭제합니다. 해당하는 이미지 또한 S3 버킷에서 삭제합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "일기 삭제 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 리소스입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diary.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Visibility;
 import org.lxdproject.lxd.member.entity.Member;
@@ -24,6 +25,8 @@ public class DiaryDetailResponseDTO {
     private int likeCount;
     private int correctCount;
     private String content;
+    private CommentPermission commentPermission;
+    private String thumbnail;
 
     public static DiaryDetailResponseDTO from(Diary diary) {
         Member member = diary.getMember();
@@ -40,7 +43,9 @@ public class DiaryDetailResponseDTO {
                 diary.getCommentCount(),
                 diary.getLikeCount(),
                 diary.getCorrectionCount(),
-                diary.getContent()
+                diary.getContent(),
+                diary.getCommentPermission(),
+                diary.getThumbImg()
         );
     }
 

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryRequestDTO.java
@@ -7,12 +7,14 @@ import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Style;
 import org.lxdproject.lxd.diary.entity.enums.Visibility;
+import org.lxdproject.lxd.validation.annotation.MaxImageCount;
 
 @Getter @Setter
 public class DiaryRequestDTO {
     @NotBlank(message = "제목을 작성해주세요.")
     private String title;
     @NotBlank(message = "내용을 작성해주세요.")
+    @MaxImageCount
     private String content;
     private Style style;
     private Visibility visibility;

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -86,7 +86,7 @@ public class DiaryService {
 
     private static final Pattern IMG_URL_PATTERN = Pattern.compile("<img[^>]+src=[\"']?([^\"'>]+)[\"']?");
 
-    public List<String> extractImageUrls(String htmlContent) {
+    private List<String> extractImageUrls(String htmlContent) {
         List<String> imageUrls = new ArrayList<>();
         Matcher matcher = IMG_URL_PATTERN.matcher(htmlContent);
         while (matcher.find()) {

--- a/src/main/java/org/lxdproject/lxd/validation/annotation/MaxImageCount.java
+++ b/src/main/java/org/lxdproject/lxd/validation/annotation/MaxImageCount.java
@@ -1,0 +1,19 @@
+package org.lxdproject.lxd.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.lxdproject.lxd.validation.validator.MaxImageCountValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = MaxImageCountValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxImageCount {
+    String message() default "이미지 개수 제한을 초과했습니다.";
+    int max() default 5;
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/lxdproject/lxd/validation/validator/MaxImageCountValidator.java
+++ b/src/main/java/org/lxdproject/lxd/validation/validator/MaxImageCountValidator.java
@@ -24,6 +24,10 @@ public class MaxImageCountValidator implements ConstraintValidator<MaxImageCount
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true; // null 값은 @NotBlank로 처리함
+        }
+
         int count = countImgTags(value);
         boolean isValid = count <= max;
 
@@ -38,7 +42,7 @@ public class MaxImageCountValidator implements ConstraintValidator<MaxImageCount
     }
 
     private int countImgTags(String html) {
-        Pattern pattern = Pattern.compile("<img\\s+[^>]*src=[\"'][^\"']+[\"'][^>]*>");
+        Pattern pattern = Pattern.compile("<img[^>]+src=[\"']?([^\"'>]+)[\"']?");
         Matcher matcher = pattern.matcher(html);
         int count = 0;
         while (matcher.find()) count++;

--- a/src/main/java/org/lxdproject/lxd/validation/validator/MaxImageCountValidator.java
+++ b/src/main/java/org/lxdproject/lxd/validation/validator/MaxImageCountValidator.java
@@ -1,0 +1,47 @@
+package org.lxdproject.lxd.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.validation.annotation.MaxImageCount;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class MaxImageCountValidator implements ConstraintValidator<MaxImageCount, String> {
+
+    private int max;
+
+    @Override
+    public void initialize(MaxImageCount constraintAnnotation) {
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        int count = countImgTags(value);
+        boolean isValid = count <= max;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context
+                    .buildConstraintViolationWithTemplate(ErrorStatus.TOO_MANY_IMAGES.toString())
+                    .addConstraintViolation();
+        }
+
+        return isValid;
+    }
+
+    private int countImgTags(String html) {
+        Pattern pattern = Pattern.compile("<img\\s+[^>]*src=[\"'][^\"']+[\"'][^>]*>");
+        Matcher matcher = pattern.matcher(html);
+        int count = 0;
+        while (matcher.find()) count++;
+        return count;
+    }
+}


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
related #17 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기 작성 시 이미지 갯수에 따른 에러 핸들링
일기 삭제 시 관련 이미지 또한 S3 버킷에서 삭제

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
### 이미지 5개 초과로 요청
일기 작성 시 이미지 5개 초과로 요청한다면 다음과 같이 응답합니다.
`{
  "isSuccess": false,
  "code": "COMMON400",
  "message": "잘못된 요청입니다.",
  "result": {
    "content": "TOO_MANY_IMAGES"
  }
}`

### 일기 삭제 요청 시 이미지 S3에서 삭제
일기 content에서 <img src""> 를 모두 추출하고 S3에서 삭제 시 필요한 key 값을 리스트에 담습니다.
이를 stream으로 DeleteObjectsRequest를 만들어 하나씩 삭제합니다.
모두 삭제 성공 시 `모든 S3 이미지 삭제 성공` 라는 로그를 출력합니다.
일부 실패 시 `일부 S3 이미지 삭제 실패: {}`, 예외 발생 시 `S3 이미지 삭제 중 예외 발생: {}` 라는 로그를  출력합니다.


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 다이어리 상세 응답에 댓글 권한 및 썸네일 정보가 추가되었습니다.
  * 다이어리 삭제 시 첨부된 이미지가 S3에서 함께 삭제됩니다.
  * 다중 이미지 삭제 기능이 도입되어 S3 이미지 관리가 개선되었습니다.

* **버그 수정**
  * 다이어리 작성 시 이미지는 최대 5개까지만 첨부할 수 있도록 제한 및 검증이 추가되었습니다.
  * 이미지 개수 제한 초과 시 적절한 오류 메시지가 제공됩니다.

* **문서화**
  * 다이어리 삭제 API 설명에 이미지 삭제 내용이 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->