### PR TITLE
[FEATURE] 일기 교정 조회 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/corrections")
 public interface CorrectionApi {
 
-    @GetMapping("/{diaryId}/corrections")
+    @GetMapping("/diary/{diaryId}")
     @Operation(
             summary = "일기 상세 내 교정 목록 조회",
             description = "특정 일기에 작성된 교정 리스트를 최신순으로 조회합니다.",

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
@@ -26,7 +26,7 @@ public interface CorrectionApi {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID")
             }
     )
-    ApiResponse<Slice<CorrectionResponseDTO.CorrectionDetailDTO>> getDiaryCorrections(
+    ApiResponse<CorrectionResponseDTO.DiaryCorrectionsResponseDTO> getDiaryCorrections(
             @PathVariable Long diaryId,
             @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "한 페이지에 포함할 교정 개수", example = "10") @RequestParam(defaultValue = "10") int size,

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
@@ -8,12 +8,30 @@ import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
 import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Correction API", description = "교정 관련 API입니다.")
 @RequestMapping("/corrections")
 public interface CorrectionApi {
+
+    @GetMapping("/{diaryId}/corrections")
+    @Operation(
+            summary = "일기 상세 내 교정 목록 조회",
+            description = "특정 일기에 작성된 교정 리스트를 최신순으로 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 일기 ID")
+            }
+    )
+    ApiResponse<Slice<CorrectionResponseDTO.CorrectionDetailDTO>> getDiaryCorrections(
+            @PathVariable Long diaryId,
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "한 페이지에 포함할 교정 개수", example = "10") @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal Member member
+    );
 
     @Operation(
             summary = "교정 등록 API",
@@ -26,7 +44,7 @@ public interface CorrectionApi {
             }
     )
     @PostMapping
-    ApiResponse<CorrectionResponseDTO.CreateResponseDTO> createCorrection(
+    ApiResponse<CorrectionResponseDTO.CorrectionDetailDTO> createCorrection(
             @RequestBody @Valid CorrectionRequestDTO.CreateRequestDTO requestDto,
             @AuthenticationPrincipal Member member
     );

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionApi.java
@@ -8,7 +8,6 @@ import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
 import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
-import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -19,7 +19,7 @@ public class CorrectionRestController implements CorrectionApi {
     private final CorrectionService correctionService;
 
     @Override
-    public ApiResponse<Slice<CorrectionResponseDTO.CorrectionDetailDTO>> getDiaryCorrections(
+    public ApiResponse<CorrectionResponseDTO.DiaryCorrectionsResponseDTO> getDiaryCorrections(
             Long diaryId, int page, int size, Member member) {
         return ApiResponse.onSuccess(correctionService.getCorrectionsByDiaryId(diaryId, page, size, member));
     }

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -6,6 +6,7 @@ import org.lxdproject.lxd.correction.dto.CorrectionRequestDTO;
 import org.lxdproject.lxd.correction.dto.CorrectionResponseDTO;
 import org.lxdproject.lxd.correction.service.CorrectionService;
 import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.domain.Slice;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +19,13 @@ public class CorrectionRestController implements CorrectionApi {
     private final CorrectionService correctionService;
 
     @Override
-    public ApiResponse<CorrectionResponseDTO.CreateResponseDTO> createCorrection(
+    public ApiResponse<Slice<CorrectionResponseDTO.CorrectionDetailDTO>> getDiaryCorrections(
+            Long diaryId, int page, int size, Member member) {
+        return ApiResponse.onSuccess(correctionService.getCorrectionsByDiaryId(diaryId, page, size, member));
+    }
+
+    @Override
+    public ApiResponse<CorrectionResponseDTO.CorrectionDetailDTO> createCorrection(
             CorrectionRequestDTO.CreateRequestDTO requestDto,
             Member member
     ) {

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -9,7 +9,13 @@ public class CorrectionResponseDTO {
 
     @Getter
     @Builder
-    public static class CreateResponseDTO {
+    public static class DiaryCorrectionsResponseDto{
+
+    }
+
+    @Getter
+    @Builder
+    public static class CorrectionDetailDTO {
         private Long correctionId;
         private Long diaryId;
         private String createdAt;

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -9,8 +9,11 @@ public class CorrectionResponseDTO {
 
     @Getter
     @Builder
-    public static class DiaryCorrectionsResponseDto{
-
+    public static class DiaryCorrectionsResponseDTO{
+        private Long diaryId;
+        private int totalCount; // 전체 교정 수
+        private boolean hasNext; // 다음 페이지 존재 여부
+        private List<CorrectionDetailDTO> corrections;
     }
 
     @Getter

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -22,7 +22,7 @@ public class CorrectionResponseDTO {
         private Long correctionId;
         private Long diaryId;
         private String createdAt;
-        private AuthorDTO author;
+        private MemberDTO member;
         private String original;
         private String corrected;
         private String commentText;
@@ -33,7 +33,7 @@ public class CorrectionResponseDTO {
 
     @Getter
     @Builder
-    public static class AuthorDTO {
+    public static class MemberDTO {
         private Long memberId;
         private String userId;
         private String nickname;
@@ -56,7 +56,7 @@ public class CorrectionResponseDTO {
     @Getter
     @Builder
     public static class ProvidedCorrectionsResponseDTO {
-        private AuthorDTO member;
+        private MemberDTO member;
         private List<CorrectionItem> corrections;
         private int page;
         private int size;

--- a/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
+++ b/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.correction.entity.mapping;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.lxdproject.lxd.common.entity.BaseEntity;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.member.entity.Member;
 
@@ -10,7 +11,7 @@ import org.lxdproject.lxd.member.entity.Member;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MemberSavedCorrection {
+public class MemberSavedCorrection extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
@@ -4,8 +4,14 @@ import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
-    Page<Correction> findByAuthor(Member author, Pageable pageable);
+    Slice<Correction> findByAuthor(Member author, Pageable pageable);
+
 }

--- a/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correction/repository/CorrectionRepository.java
@@ -13,5 +13,5 @@ import java.util.List;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long> {
     Slice<Correction> findByAuthor(Member author, Pageable pageable);
-
+    Slice<Correction> findByDiaryId(Long diaryId, Pageable pageable);
 }

--- a/src/main/java/org/lxdproject/lxd/correction/repository/MemberSavedCorrectionRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correction/repository/MemberSavedCorrectionRepository.java
@@ -1,0 +1,20 @@
+package org.lxdproject.lxd.correction.repository;
+
+import org.lxdproject.lxd.correction.entity.mapping.MemberSavedCorrection;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberSavedCorrectionRepository extends JpaRepository<MemberSavedCorrection, Long> {
+
+    @Query("SELECT msc.correction.id FROM MemberSavedCorrection msc " +
+            "WHERE msc.member = :member AND msc.correction.id IN :correctionIds")
+    List<Long> findLikedCorrectionIdsByMember(
+            @Param("member") Member member,
+            @Param("correctionIds") List<Long> correctionIds
+    );
+}
+

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -55,7 +55,7 @@ public class CorrectionService {
                         .likeCount(correction.getLikeCount())
                         .commentCount(correction.getCommentCount())
                         .isLikedByMe(likedIds.contains(correction.getId()))
-                        .author(CorrectionResponseDTO.AuthorDTO.builder()
+                        .member(CorrectionResponseDTO.MemberDTO.builder()
                                 .memberId(correction.getAuthor().getId())
                                 .userId(correction.getAuthor().getUsername())
                                 .nickname(correction.getAuthor().getNickname())
@@ -102,7 +102,7 @@ public class CorrectionService {
                 .likeCount(saved.getLikeCount())
                 .commentCount(saved.getCommentCount())
                 .isLikedByMe(false)
-                .author(CorrectionResponseDTO.AuthorDTO.builder()
+                .member(CorrectionResponseDTO.MemberDTO.builder()
                         .memberId(author.getId())
                         .userId(author.getUsername())
                         .nickname(author.getNickname())
@@ -131,7 +131,7 @@ public class CorrectionService {
                 .toList();
 
         return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
-                .member(CorrectionResponseDTO.AuthorDTO.builder()
+                .member(CorrectionResponseDTO.MemberDTO.builder()
                         .memberId(member.getId())
                         .userId(member.getUsername())
                         .nickname(member.getNickname())


### PR DESCRIPTION
## 📌 Issue number and Link
closed #41 

## ✏️ Summary
- 일기 내에 작성된 교정 조회(무한 스크롤 기반) API를 구현했습니다.
- 기존 내가 작성한 교정 조회 API의 Response type을 변경하였습니다. 

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
- 일기 내 작성된 교정 조회 API 구현 
- 기존 내가 작성한 교정 조희 API의 Page<Correction> -> Slice<Correction>으로 변경
- CreateCorrectionResponse 등의 Correction반환을 CorrectionDetailDTO로 변환
- Swagger 작성

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 일기의 교정 목록을 페이지네이션하여 조회할 수 있는 기능이 추가되었습니다.

* **기능 개선**
  * 교정 생성 시 반환되는 응답이 교정 상세 정보로 변경되어, 더 많은 정보를 확인할 수 있습니다.
  * 내가 제공한 교정 목록 조회 시 응답 구조가 개선되어, 페이지네이션 처리 방식이 변경되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 일부 내부 데이터 구조 및 명칭이 정비되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->