### PR TITLE
[FEATURE] 좋아요한 교정 내 메모 CUD API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/CorrectionHandler.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/handler/CorrectionHandler.java
@@ -1,4 +1,9 @@
 package org.lxdproject.lxd.apiPayload.code.exception.handler;
 
-public class CorrectionHandler {
+import org.lxdproject.lxd.apiPayload.code.status.BaseErrorCode;
+
+public class CorrectionHandler extends GeneralException {
+    public CorrectionHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 교정 관련 에러
     CORRECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "CORRECTION4400", "교정을 찾을 수 없습니다."),
     INVALID_CORRECTION_MEMO(HttpStatus.NOT_FOUND, "CORRECTION4401", "이미 메모가 존재하는 교정입니다."),
+    MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "CORRECTION4402", "메모가 생성되어있지 않습니다. 업데이트가 아닌 메모 생성을 해야합니다."),
 
     // 테스트 용 응답
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "PAGE400", "유효하지 않은 페이지 번호입니다."),

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -35,6 +35,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 메일 관련 에러
     UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL 4301", "이메일을 보낼 수 없습니다."),
 
+    // 교정 관련 에러
+    CORRECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "CORRECTION4400", "교정을 찾을 수 없습니다."),
+    INVALID_CORRECTION_MEMO(HttpStatus.NOT_FOUND, "CORRECTION4401", "이미 메모가 존재하는 교정입니다."),
+
     // 테스트 용 응답
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "PAGE400", "유효하지 않은 페이지 번호입니다."),
     TEST_FAIL(HttpStatus.BAD_REQUEST, "TEST400", "사용자 정의 실패 응답입니다."),

--- a/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/CorrectionRestController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/corrections")
-@Validated
 public class CorrectionRestController implements CorrectionApi {
 
     private final CorrectionService correctionService;

--- a/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionApi.java
@@ -33,7 +33,7 @@ public interface MemberSavedCorrectionApi {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 저장 교정 ID")
             }
     )
-    @PutMapping("/memo")
+    @PatchMapping("/memo")
     ApiResponse<MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO> updateMemo(
             @RequestBody @Valid MemberSavedCorrectionRequestDTO.MemoRequestDTO request
     );

--- a/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionApi.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionApi.java
@@ -1,0 +1,51 @@
+package org.lxdproject.lxd.correction.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionResponseDTO;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Member Saved Correction API", description = "표현 학습(사용자 저장 교정) 관련 API입니다.")
+@RequestMapping("/saved-corrections")
+public interface MemberSavedCorrectionApi {
+
+    @Operation(
+            summary = "저장된 교정 내 메모 작성",
+            description = "저장한 교정에 메모를 작성합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "메모 등록 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 메모가 존재함 또는 유효성 오류")
+            }
+    )
+    @PostMapping("/memo")
+    ApiResponse<MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO> createMemo(
+            @RequestBody @Valid MemberSavedCorrectionRequestDTO.MemoRequestDTO request
+    );
+
+    @Operation(
+            summary = "저장된 교정 내 메모 수정",
+            description = "저장한 교정에 작성한 메모를 수정합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메모 수정 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 저장 교정 ID")
+            }
+    )
+    @PutMapping("/memo")
+    ApiResponse<MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO> updateMemo(
+            @RequestBody @Valid MemberSavedCorrectionRequestDTO.MemoRequestDTO request
+    );
+
+    @Operation(
+            summary = "저장된 교정 내 메모 삭제",
+            description = "저장한 교정에 작성한 메모를 삭제합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메모 삭제 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 저장 교정 ID")
+            }
+    )
+    @DeleteMapping("/{correctionId}/memo")
+    ApiResponse<MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO> deleteMemo(@PathVariable Long correctionId);
+}

--- a/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionController.java
+++ b/src/main/java/org/lxdproject/lxd/correction/controller/MemberSavedCorrectionController.java
@@ -1,0 +1,30 @@
+package org.lxdproject.lxd.correction.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionResponseDTO;
+import org.lxdproject.lxd.correction.service.MemberSavedCorrectionService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberSavedCorrectionController implements MemberSavedCorrectionApi {
+
+    private final MemberSavedCorrectionService memberSavedCorrectionService;
+
+    @Override
+    public ApiResponse<MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO> createMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
+        return  ApiResponse.onSuccess(memberSavedCorrectionService.createMemo(request));
+    }
+
+    @Override
+    public ApiResponse<MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO> updateMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
+        return  ApiResponse.onSuccess(memberSavedCorrectionService.updateMemo(request));
+    }
+
+    @Override
+    public ApiResponse<MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO> deleteMemo(Long correctionId) {
+        return ApiResponse.onSuccess(memberSavedCorrectionService.deleteMemo(correctionId));
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -42,7 +42,7 @@ public class CorrectionResponseDTO {
 
     @Getter
     @Builder
-    public static class CorrectionItem {
+    public static class SavedCorrectionItem {
         private Long correctionId;
         private Long diaryId;
         private String diaryTitle;
@@ -57,7 +57,7 @@ public class CorrectionResponseDTO {
     @Builder
     public static class ProvidedCorrectionsResponseDTO {
         private MemberDTO member;
-        private List<CorrectionItem> corrections;
+        private List<SavedCorrectionItem> corrections;
         private int page;
         private int size;
         private int totalCount;

--- a/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionRequestDTO.java
@@ -15,12 +15,12 @@ public class MemberSavedCorrectionRequestDTO {
     @Schema(description = "메모 요청 DTO")
     public static class MemoRequestDTO {
 
-        @NotNull(message = "correctionId는 필수입니다.")
-        @Schema(description = "저장 교정 ID", example = "42")
-        private Long correctionId;
+        @NotNull(message = "memberSavedCorrectionId는 필수입니다.")
+        @Schema(description = "회원이 저장한 교정 ID", example = "812")
+        private Long memberSavedCorrectionId;
 
         @NotBlank(message = "메모는 비어 있을 수 없습니다.")
-        @Schema(description = "저장 교정 내 메모 내용", example = "ex) 이 부분 잊지말자!")
+        @Schema(description = "저장 교정 내 메모 내용", example = "이 부분 잊지말자!")
         private String memo;
     }
 }

--- a/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionRequestDTO.java
@@ -1,0 +1,26 @@
+package org.lxdproject.lxd.correction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberSavedCorrectionRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "메모 요청 DTO")
+    public static class MemoRequestDTO {
+
+        @NotNull(message = "correctionId는 필수입니다.")
+        @Schema(description = "저장 교정 ID", example = "42")
+        private Long correctionId;
+
+        @NotBlank(message = "메모는 비어 있을 수 없습니다.")
+        @Schema(description = "저장 교정 내 메모 내용", example = "ex) 이 부분 잊지말자!")
+        private String memo;
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
@@ -14,7 +14,7 @@ public class MemberSavedCorrectionResponseDTO {
     @Builder
     public static class CreateMemoResponseDTO {
 
-        private Long correctionId;
+        private Long memberSavedCorrectionId;
         private String createdMemo;
         private LocalDateTime createdAt;
     }
@@ -31,7 +31,7 @@ public class MemberSavedCorrectionResponseDTO {
     @Builder
     public static class DeleteMemoResponseDTO {
 
-        private Long correctionId;
+        private Long memberSavedCorrectionId;
         private LocalDateTime deletedAt;
         private String message;
     }

--- a/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
@@ -1,0 +1,37 @@
+package org.lxdproject.lxd.correction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MemberSavedCorrectionResponseDTO {
+
+    @Getter
+    @Builder
+    public static class CreateMemoResponseDTO {
+
+        private Long correctionId;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class UpdateMemoResponseDTO {
+
+        private String updatedMemo;
+        private LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    public static class DeleteMemoResponseDTO {
+
+        private Long correctionId;
+        private LocalDateTime deletedAt;
+        private String message;
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/MemberSavedCorrectionResponseDTO.java
@@ -15,6 +15,7 @@ public class MemberSavedCorrectionResponseDTO {
     public static class CreateMemoResponseDTO {
 
         private Long correctionId;
+        private String createdMemo;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
+++ b/src/main/java/org/lxdproject/lxd/correction/entity/mapping/MemberSavedCorrection.java
@@ -25,7 +25,9 @@ public class MemberSavedCorrection extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Setter
     @Column(name = "memo")
     private String memo;
+
 }
 

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -117,8 +117,8 @@ public class CorrectionService {
 
         Slice<Correction> corrections = correctionRepository.findByAuthor(member, pageable);
 
-        List<CorrectionResponseDTO.CorrectionItem> correctionItems = corrections.getContent().stream()
-                .map(correction -> CorrectionResponseDTO.CorrectionItem.builder()
+        List<CorrectionResponseDTO.SavedCorrectionItem> correctionItems = corrections.getContent().stream()
+                .map(correction -> CorrectionResponseDTO.SavedCorrectionItem.builder()
                         .correctionId(correction.getId())
                         .diaryId(correction.getDiary().getId())
                         .diaryTitle(correction.getDiary().getTitle())

--- a/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
@@ -9,6 +9,8 @@ import org.lxdproject.lxd.correction.repository.MemberSavedCorrectionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.CORRECTION_NOT_FOUND;
 import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.INVALID_CORRECTION_MEMO;
 
@@ -29,7 +31,8 @@ public class MemberSavedCorrectionService {
         entity.setMemo(request.getMemo());
         return MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO.builder()
                 .correctionId(entity.getId())
-                .createdAt(entity.getUpdatedAt())
+                .createdMemo(request.getMemo())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
@@ -11,8 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
-import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.CORRECTION_NOT_FOUND;
-import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.INVALID_CORRECTION_MEMO;
+import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +21,7 @@ public class MemberSavedCorrectionService {
 
     @Transactional
     public MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO createMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
-        MemberSavedCorrection entity = getCorrectionOrThrow(request.getCorrectionId());
+        MemberSavedCorrection entity = getCorrectionOrThrow(request.getMemberSavedCorrectionId());
 
         if (entity.getMemo() != null && !entity.getMemo().isBlank()) {
             throw new CorrectionHandler(INVALID_CORRECTION_MEMO);
@@ -30,7 +29,7 @@ public class MemberSavedCorrectionService {
 
         entity.setMemo(request.getMemo());
         return MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO.builder()
-                .correctionId(entity.getId())
+                .memberSavedCorrectionId(entity.getId())
                 .createdMemo(request.getMemo())
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -38,7 +37,11 @@ public class MemberSavedCorrectionService {
 
     @Transactional
     public MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO updateMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
-        MemberSavedCorrection entity = getCorrectionOrThrow(request.getCorrectionId());
+        MemberSavedCorrection entity = getCorrectionOrThrow(request.getMemberSavedCorrectionId());
+
+        if (entity.getMemo() == null || entity.getMemo().isBlank()) {
+            throw new CorrectionHandler(MEMO_NOT_FOUND);
+        }
 
         entity.setMemo(request.getMemo());
         return MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO.builder()
@@ -48,13 +51,13 @@ public class MemberSavedCorrectionService {
     }
 
     @Transactional
-    public MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO deleteMemo(Long correctionId) {
-        MemberSavedCorrection entity = getCorrectionOrThrow(correctionId);
+    public MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO deleteMemo(Long memberSavedCorrectionId) {
+        MemberSavedCorrection entity = getCorrectionOrThrow(memberSavedCorrectionId);
         entity.setMemo(null);
 
         return MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO.builder()
-                .correctionId(entity.getId())
-                .deletedAt(entity.getUpdatedAt())
+                .memberSavedCorrectionId(entity.getId())
+                .deletedAt(LocalDateTime.now())
                 .message("메모가 성공적으로 삭제되었습니다.")
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/MemberSavedCorrectionService.java
@@ -1,0 +1,63 @@
+package org.lxdproject.lxd.correction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionRequestDTO;
+import org.lxdproject.lxd.correction.dto.MemberSavedCorrectionResponseDTO;
+import org.lxdproject.lxd.correction.entity.mapping.MemberSavedCorrection;
+import org.lxdproject.lxd.correction.repository.MemberSavedCorrectionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.CORRECTION_NOT_FOUND;
+import static org.lxdproject.lxd.apiPayload.code.status.ErrorStatus.INVALID_CORRECTION_MEMO;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSavedCorrectionService {
+
+    private final MemberSavedCorrectionRepository memberSavedCorrectionRepository;
+
+    @Transactional
+    public MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO createMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
+        MemberSavedCorrection entity = getCorrectionOrThrow(request.getCorrectionId());
+
+        if (entity.getMemo() != null && !entity.getMemo().isBlank()) {
+            throw new CorrectionHandler(INVALID_CORRECTION_MEMO);
+        }
+
+        entity.setMemo(request.getMemo());
+        return MemberSavedCorrectionResponseDTO.CreateMemoResponseDTO.builder()
+                .correctionId(entity.getId())
+                .createdAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO updateMemo(MemberSavedCorrectionRequestDTO.MemoRequestDTO request) {
+        MemberSavedCorrection entity = getCorrectionOrThrow(request.getCorrectionId());
+
+        entity.setMemo(request.getMemo());
+        return MemberSavedCorrectionResponseDTO.UpdateMemoResponseDTO.builder()
+                .updatedMemo(request.getMemo())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO deleteMemo(Long correctionId) {
+        MemberSavedCorrection entity = getCorrectionOrThrow(correctionId);
+        entity.setMemo(null);
+
+        return MemberSavedCorrectionResponseDTO.DeleteMemoResponseDTO.builder()
+                .correctionId(entity.getId())
+                .deletedAt(entity.getUpdatedAt())
+                .message("메모가 성공적으로 삭제되었습니다.")
+                .build();
+    }
+
+    private MemberSavedCorrection getCorrectionOrThrow(Long id) {
+        return memberSavedCorrectionRepository.findById(id)
+                .orElseThrow(() -> new CorrectionHandler(CORRECTION_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 Issue number and Link
closed #56 

## ✏️ Summary
좋아요한 교정 내 메모 CUD API 구현 

## 📝 Changes
- 좋아요한 교정 내 메모 작성, 삭제, 업데이트 API를 구현
- CorrectionHandler 추가 
- CorrectionItem -> SavedCorrectionItem으로 리네이밍 
- 조회는 저장한 교정 조회에서 함께 구현 예정 

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원이 저장한 교정에 메모를 생성, 수정, 삭제할 수 있는 API가 추가되었습니다.
  * 메모 생성, 수정, 삭제에 대한 응답 DTO가 추가되었습니다.

* **버그 수정**
  * 교정 관련 오류 상태 코드가 추가되어, 교정이 존재하지 않거나 이미 메모가 있는 경우에 대한 명확한 오류 메시지가 제공됩니다.

* **리팩터링**
  * 교정 응답 DTO의 클래스 및 필드명이 명확하게 변경되었습니다.
  * 일부 컨트롤러의 URL 매핑 및 유효성 검사 어노테이션이 정리되었습니다.

* **기타**
  * 메모 필드에 setter가 추가되어 메모 수정이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->