### PR TITLE
[REFACTOR] 회원가입 API 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_DUPLICATION(HttpStatus.CONFLICT, "MEMBER4311", "이미 존재하는 이메일입니다."),
     NICKNAME_DUPLICATION(HttpStatus.CONFLICT, "MEMBER4312", "이미 존재하는 닉네임입니다."),
     PRIVACY_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "MEMBER4313", "개인정보 동의는 필수입니다."),
+    USERNAME_DUPLICATION(HttpStatus.CONFLICT, "MEMBER4314", "이미 존재하는 아이디입니다."),
 
     // 인증 관련 에러
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4300", "토큰이 올바르지 않습니다."),

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -31,5 +31,5 @@ public interface MemberApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이메일, 닉네임 중복", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
 
     })
-    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestPart @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart MultipartFile profileImg);
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestPart(value = "data") @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart(required = false) MultipartFile profileImg);
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -13,18 +13,17 @@ import org.lxdproject.lxd.member.dto.MemberRequestDTO;
 import org.lxdproject.lxd.member.dto.MemberResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.service.MemberService;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "Member API", description = "사용자 관련 API 입니다.")
 @RequestMapping("/members")
 public interface MemberApi {
 
-    @PostMapping("/join")
+    @PostMapping(value = "/join", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "회원가입 api", description = "계정 생성")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
@@ -32,5 +31,5 @@ public interface MemberApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이메일, 닉네임 중복", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
 
     })
-    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO);
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestPart @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart MultipartFile profileImg);
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @Override
-    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart MultipartFile profileImg) {
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestPart(value = "data") @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart(required = false) MultipartFile profileImg) {
 
         Member member = memberService.join(joinRequestDTO, profileImg);
         return ApiResponse.onSuccess(MemberConverter.toJoinResponseDTO(member));

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.service.MemberService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,9 +21,9 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @Override
-    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
+    public ApiResponse<MemberResponseDTO.JoinResponseDTO> join(@RequestBody @Valid MemberRequestDTO.JoinRequestDTO joinRequestDTO, @RequestPart MultipartFile profileImg) {
 
-        Member member = memberService.join(joinRequestDTO);
+        Member member = memberService.join(joinRequestDTO, profileImg);
         return ApiResponse.onSuccess(MemberConverter.toJoinResponseDTO(member));
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
+++ b/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
@@ -1,5 +1,6 @@
 package org.lxdproject.lxd.member.converter;
 
+import org.lxdproject.lxd.common.dto.ImageResponseDTO;
 import org.lxdproject.lxd.member.dto.MemberRequestDTO;
 import org.lxdproject.lxd.member.dto.MemberResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
@@ -22,7 +23,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public static Member toMember(MemberRequestDTO.JoinRequestDTO joinRequestDTO, String encryptedPassword) {
+    public static Member toMember(MemberRequestDTO.JoinRequestDTO joinRequestDTO, String profileURL, String encryptedPassword) {
         return Member.builder()
                 .nativeLanguage(joinRequestDTO.getNativeLanguage())
                 .language(joinRequestDTO.getLanguage())
@@ -33,7 +34,7 @@ public class MemberConverter {
                 .nickname(joinRequestDTO.getNickname())
                 .loginType(joinRequestDTO.getLoginType())
                 .isPrivacyAgreed(joinRequestDTO.getIsPrivacyAgreed())
-                .profileImg(joinRequestDTO.getProfileImg())
+                .profileImg(profileURL)
                 .status(Status.ACTIVE)
                 .isAlarmAgreed(Boolean.FALSE) // 알람은 꺼져있는게 Default
                 .build();

--- a/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
+++ b/src/main/java/org/lxdproject/lxd/member/converter/MemberConverter.java
@@ -18,7 +18,8 @@ public class MemberConverter {
                         .username(member.getUsername())
                         .nickname(member.getNickname())
                         .profileImg(member.getProfileImg())
-                        .language(member.getLanguage().name())
+                        .nativeLanguage(member.getNativeLanguage().name())
+                        .studyLanguage(member.getLanguage().name())
                         .build())
                 .build();
     }
@@ -26,7 +27,7 @@ public class MemberConverter {
     public static Member toMember(MemberRequestDTO.JoinRequestDTO joinRequestDTO, String profileURL, String encryptedPassword) {
         return Member.builder()
                 .nativeLanguage(joinRequestDTO.getNativeLanguage())
-                .language(joinRequestDTO.getLanguage())
+                .language(joinRequestDTO.getStudyLanguage())
                 .role(Role.USER)
                 .username(joinRequestDTO.getUsername())
                 .password(encryptedPassword)

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -56,7 +56,7 @@ public class MemberRequestDTO {
         // 학습언어
         @NotNull(message = "학습언어는 필수입니다.")
         @Schema(description = "학습 언어", example = "KO")
-        private Language language;
+        private Language studyLanguage;
 
         @NotNull(message = "로그인 방식을 지정해주어야 합니다.")
         @Schema(description = "로그인 방식", example = "LOCAL")

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -45,8 +45,8 @@ public class MemberRequestDTO {
         @Schema(description = "닉네임", example = "눈사람")
         String nickname;
 
-        @Schema(description = "프로필 이미지", example = "https://image.jpg")
-        String profileImg;
+        // @Schema(description = "프로필 이미지", example = "https://image.jpg")
+        // String profileImg;
 
         // 주사용언어
         @NotNull(message = "주 사용언어는 필수입니다.")

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberResponseDTO.java
@@ -39,8 +39,11 @@ public class MemberResponseDTO {
             @Schema(description = "프로필 이미지 URL")
             private String profileImg;
 
-            @Schema(description = "선택 언어 (KO, ENG 등)")
-            private String language;
+            @Schema(description = "주 사용언어", example = "KO")
+            private String nativeLanguage;
+
+            @Schema(description = "학습 언어", example = "ENG")
+            private String studyLanguage;
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -9,6 +9,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmail(String email);
     Boolean existsByNickname(String nickname);
+    Boolean existsByUsername(String username);
 
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -4,6 +4,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.common.dto.ImageResponseDTO;
+import org.lxdproject.lxd.common.entity.enums.ImageDir;
+import org.lxdproject.lxd.common.service.ImageService;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.member.converter.MemberConverter;
 import org.lxdproject.lxd.member.dto.MemberRequestDTO;
@@ -14,6 +17,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,6 +26,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ImageService imageService;
 
     public Member join(MemberRequestDTO.JoinRequestDTO joinRequestDTO, MultipartFile profileImg) {
 
@@ -41,9 +47,19 @@ public class MemberService {
             throw new MemberHandler(ErrorStatus.NICKNAME_DUPLICATION);
         }
 
-        Member member = MemberConverter.toMember(joinRequestDTO, passwordEncoder.encode(joinRequestDTO.getPassword()));
+        String profileImgURL  = null;
+        Member member = null;
+
+        // 프로필 이미지가 있는 경우
+        if(profileImg != null && !profileImg.isEmpty()) {
+            profileImgURL = imageService.uploadImage(profileImg, ImageDir.PROFILE).getImageUrl();
+            member = MemberConverter.toMember(joinRequestDTO, profileImgURL ,passwordEncoder.encode(joinRequestDTO.getPassword()));
+        }else{
+            member = MemberConverter.toMember(joinRequestDTO, profileImgURL ,passwordEncoder.encode(joinRequestDTO.getPassword()));
+        }
 
         memberRepository.save(member);
+
         return member;
 
     }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -33,6 +33,10 @@ public class MemberService {
             throw new MemberHandler(ErrorStatus.EMAIL_DUPLICATION);
         }
 
+        if(memberRepository.existsByUsername(joinRequestDTO.getUsername())) {
+            throw new MemberHandler(ErrorStatus.USERNAME_DUPLICATION);
+        }
+
         if(memberRepository.existsByNickname(joinRequestDTO.getNickname())) {
             throw new MemberHandler(ErrorStatus.NICKNAME_DUPLICATION);
         }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -12,6 +12,7 @@ import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +22,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Member join(MemberRequestDTO.JoinRequestDTO joinRequestDTO) {
+    public Member join(MemberRequestDTO.JoinRequestDTO joinRequestDTO, MultipartFile profileImg) {
 
 
         if(!joinRequestDTO.getIsPrivacyAgreed().equals(Boolean.TRUE)){


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #51 

## ✏️ Summary
회원가입 API 수정

## 📝 Changes
- 프로필 이미지 저장 기능 구현
- 요청/응답 DTO에 학습 언어를 'language' -> 'studyLangauge'로 변경
- 아이디 중복확인 추가

## 🔎 PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 시 프로필 이미지 파일 업로드를 지원합니다.
  * 이미 존재하는 아이디로 회원가입 시 중복 에러 메시지가 제공됩니다.

* **버그 수정**
  * 회원가입 요청에서 학습 언어와 주 사용 언어를 각각 구분하여 입력 및 응답합니다.

* **기타**
  * 회원가입 시 아이디 중복 여부를 사전에 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->