### PR TITLE
[REFACTOR] 교정 댓글 작성/조회/삭제, 일기 댓글 좋아요 API 변경

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -1,9 +1,12 @@
 package org.lxdproject.lxd.correctioncomment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
-import org.lxdproject.lxd.correctioncomment.dto.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentDeleteResponseDTO;
+import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentPageResponseDTO;
+import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentRequestDTO;
+import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentResponseDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,6 +35,7 @@ public interface CorrectionCommentApi {
             @PathVariable Long commentId
     );
 }
+
 
 
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -1,8 +1,8 @@
 package org.lxdproject.lxd.correctioncomment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.lxdproject.lxd.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentDeleteResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentPageResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentRequestDTO;
@@ -10,17 +10,17 @@ import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentResponseDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "CorrectionComment", description = "교정 댓글 API")
+@Tag(name = "Correction Comment API", description = "교정 댓글 관련 API 입니다.")
 public interface CorrectionCommentApi {
 
-    @Operation(summary = "교정 댓글 작성", description = "해당 교정의 댓글을 생성합니다.")
+    @Operation(summary = "교정 댓글 작성", description = "교정 댓글 생성")
     @PostMapping("/corrections/{correctionId}/comments")
     ResponseEntity<ApiResponse<CorrectionCommentResponseDTO>> writeComment(
             @PathVariable Long correctionId,
             @RequestBody CorrectionCommentRequestDTO request
     );
 
-    @Operation(summary = "교정 댓글 조회", description = "해당 교정의 댓글들을 생성일 기준으로 조회합니다.")
+    @Operation(summary = "교정 댓글 조회", description = "교정 댓글 조회")
     @GetMapping("/corrections/{correctionId}/comments")
     ResponseEntity<ApiResponse<CorrectionCommentPageResponseDTO>> getComments(
             @PathVariable Long correctionId,
@@ -28,7 +28,7 @@ public interface CorrectionCommentApi {
             @RequestParam(defaultValue = "10") int size
     );
 
-    @Operation(summary = "교정 댓글 삭제 (Soft Delete)", description = "해당 교정의 댓글을 삭제합니다.")
+    @Operation(summary = "교정 댓글 삭제 (Soft Delete)", description = "교정 댓글 삭제")
     @DeleteMapping("/corrections/{correctionId}/comments/{commentId}")
     ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
             @PathVariable Long correctionId,

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -10,14 +10,14 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "CorrectionComment", description = "교정 댓글 API")
 public interface CorrectionCommentApi {
 
-    @Operation(summary = "교정 댓글 작성")
+    @Operation(summary = "교정 댓글 작성", description = "해당 교정의 댓글을 생성합니다.")
     @PostMapping("/corrections/{correctionId}/comments")
     ResponseEntity<ApiResponse<CorrectionCommentResponseDTO>> writeComment(
             @PathVariable Long correctionId,
             @RequestBody CorrectionCommentRequestDTO request
     );
 
-    @Operation(summary = "교정 댓글 조회")
+    @Operation(summary = "교정 댓글 조회", description = "해당 교정의 댓글들을 생성일 기준으로 조회합니다.")
     @GetMapping("/corrections/{correctionId}/comments")
     ResponseEntity<ApiResponse<CorrectionCommentPageResponseDTO>> getComments(
             @PathVariable Long correctionId,
@@ -25,11 +25,13 @@ public interface CorrectionCommentApi {
             @RequestParam(defaultValue = "10") int size
     );
 
-    @Operation(summary = "교정 댓글 삭제 (Soft Delete)")
+    @Operation(summary = "교정 댓글 삭제 (Soft Delete)", description = "해당 교정의 댓글을 삭제합니다.")
     @DeleteMapping("/corrections/{correctionId}/comments/{commentId}")
     ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
             @PathVariable Long correctionId,
             @PathVariable Long commentId
     );
 }
+
+
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -1,40 +1,46 @@
 package org.lxdproject.lxd.correctioncomment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentDeleteResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentPageResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentRequestDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentResponseDTO;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Correction Comment API", description = "교정 댓글 관련 API 입니다.")
+@RequestMapping("/corrections/{correctionId}/comments")
 public interface CorrectionCommentApi {
 
-    @Operation(summary = "교정 댓글 작성", description = "교정 댓글 생성")
-    @PostMapping("/corrections/{correctionId}/comments")
-    ResponseEntity<ApiResponse<CorrectionCommentResponseDTO>> writeComment(
+    @PostMapping
+    @Operation(summary = "교정 댓글 작성", description = "교정 댓글을 작성합니다.")
+    ApiResponse<CorrectionCommentResponseDTO> writeComment(
             @PathVariable Long correctionId,
-            @RequestBody CorrectionCommentRequestDTO request
+            @RequestBody @Valid CorrectionCommentRequestDTO request
     );
 
-    @Operation(summary = "교정 댓글 조회", description = "교정 댓글 조회")
-    @GetMapping("/corrections/{correctionId}/comments")
-    ResponseEntity<ApiResponse<CorrectionCommentPageResponseDTO>> getComments(
+
+
+
+    @Operation(summary = "교정 댓글 조회", description = "교정 댓글 목록을 조회합니다.")
+    @GetMapping
+    ApiResponse<CorrectionCommentPageResponseDTO> getComments(
             @PathVariable Long correctionId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지당 개수", example = "10") @RequestParam(defaultValue = "10") int size
     );
 
-    @Operation(summary = "교정 댓글 삭제 (Soft Delete)", description = "교정 댓글 삭제")
-    @DeleteMapping("/corrections/{correctionId}/comments/{commentId}")
-    ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
+    @Operation(summary = "교정 댓글 삭제", description = "교정 댓글을 소프트 삭제합니다.")
+    @DeleteMapping("/{commentId}")
+    ApiResponse<CorrectionCommentDeleteResponseDTO> deleteComment(
             @PathVariable Long correctionId,
             @PathVariable Long commentId
     );
 }
+
 
 
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -9,48 +9,40 @@ import org.lxdproject.lxd.correctioncomment.service.CorrectionCommentService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/corrections/{correctionId}/comments")
 public class CorrectionCommentController implements CorrectionCommentApi {
 
     private final CorrectionCommentService correctionCommentService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<CorrectionCommentResponseDTO>> writeComment(
-            @PathVariable Long correctionId,
-            @RequestBody CorrectionCommentRequestDTO request
+    @Override
+    public ApiResponse<CorrectionCommentResponseDTO> writeComment(
+            Long correctionId,
+            CorrectionCommentRequestDTO request
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        CorrectionCommentResponseDTO response = correctionCommentService.createComment(correctionId, request, memberId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
+        CorrectionCommentResponseDTO response = correctionCommentService.writeComment(memberId, correctionId, request);
+        return ApiResponse.of(SuccessStatus._OK, response);
     }
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<CorrectionCommentPageResponseDTO>> getComments(
-            @PathVariable Long correctionId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
+    @Override
+    public ApiResponse<CorrectionCommentPageResponseDTO> getComments(Long correctionId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Long userId = SecurityUtil.getCurrentMemberId();
         CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, userId, pageable);
-        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
-    @DeleteMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
-            @PathVariable Long correctionId, // 사용하지 않더라도 URL에 있으므로 필요
-            @PathVariable Long commentId
-    ) {
+    @Override
+    public ApiResponse<CorrectionCommentDeleteResponseDTO> deleteComment(Long correctionId, Long commentId) {
         Long userId = SecurityUtil.getCurrentMemberId();
         CorrectionCommentDeleteResponseDTO response = correctionCommentService.deleteComment(commentId, userId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 }
+
 
 
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/corrections/{correctionId}/comments")
-public class CorrectionCommentController {
+public class CorrectionCommentController implements CorrectionCommentApi {
 
     private final CorrectionCommentService correctionCommentService;
 
@@ -36,24 +36,22 @@ public class CorrectionCommentController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        Long memberId = SecurityUtil.getCurrentMemberId();
-        CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, memberId, pageable);
-
-        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));  //여기서 에러가?
+        Long userId = SecurityUtil.getCurrentMemberId();
+        CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, userId, pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
-            @PathVariable Long correctionId,
-            @PathVariable Long commentId,
-            @RequestParam Long memberId
+            @PathVariable Long correctionId, // 사용하지 않더라도 URL에 있으므로 필요
+            @PathVariable Long commentId
     ) {
-        CorrectionCommentDeleteResponseDTO response = correctionCommentService.deleteComment(correctionId, commentId, memberId);
+        Long userId = SecurityUtil.getCurrentMemberId();
+        CorrectionCommentDeleteResponseDTO response = correctionCommentService.deleteComment(commentId, userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
     }
-
-
 }
+
 
 
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -29,7 +29,7 @@ public class CorrectionCommentController implements CorrectionCommentApi {
 
     @Override
     public ApiResponse<CorrectionCommentPageResponseDTO> getComments(Long correctionId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
         Long userId = SecurityUtil.getCurrentMemberId();
         CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, userId, pageable);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -36,18 +36,24 @@ public class CorrectionCommentController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, pageable);
-        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        CorrectionCommentPageResponseDTO response = correctionCommentService.getComments(correctionId, memberId, pageable);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));  //여기서 에러가?
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponse<CorrectionCommentDeleteResponseDTO>> deleteComment(
             @PathVariable Long correctionId,
-            @PathVariable Long commentId
+            @PathVariable Long commentId,
+            @RequestParam Long memberId
     ) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
         CorrectionCommentDeleteResponseDTO response = correctionCommentService.deleteComment(correctionId, commentId, memberId);
         return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK, response));
     }
+
+
 }
+
+
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentDeleteResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentDeleteResponseDTO.java
@@ -12,4 +12,5 @@ public class CorrectionCommentDeleteResponseDTO {
     private boolean isDeleted;
     private String content;
     private LocalDateTime deletedAt;
+}
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentDeleteResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentDeleteResponseDTO.java
@@ -11,6 +11,5 @@ public class CorrectionCommentDeleteResponseDTO {
     private Long commentId;
     private boolean isDeleted;
     private String content;
-    private LocalDateTime deletedAt;  //getDeletedAt()이거로 변경 필요
-}
+    private LocalDateTime deletedAt;
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Builder
 public class CorrectionCommentPageResponseDTO {
     private List<Comment> replies;
-    private int totalElements;
+    private Long totalElements;
 
     @Getter
     @Builder(toBuilder = true)

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
@@ -1,14 +1,38 @@
 package org.lxdproject.lxd.correctioncomment.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
 
 @Getter
 @Builder
 public class CorrectionCommentPageResponseDTO {
-    private List<CorrectionCommentResponseDTO> replies;
-    private long totalElements;
+    private List<Comment> replies;
+    private int totalElements;
+
+    @Getter
+    @Builder(toBuilder = true)
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Comment {
+        private Long commentId;
+        private Long parentId;
+        private Long userId;
+        private String nickname;
+        private String profileImage;
+        private String content;
+        private int likeCount;
+        private boolean isLiked;
+        private LocalDateTime createdAt;
+        private List<Comment> replies;  //대댓글
+    }
+
 }
+
+
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentPageResponseDTO.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Getter
 @Builder
 public class CorrectionCommentPageResponseDTO {
-    private List<CorrectionCommentResponseDTO> comments;
+    private List<CorrectionCommentResponseDTO> replies;
     private long totalElements;
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public class CorrectionCommentRequestDTO {
 
     @Schema(description = "댓글 내용", example = "정말 좋은 교정이에요!")
+    private Long parentId; // 대댓글일 경우 필요
     private String commentText;
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
@@ -2,12 +2,21 @@ package org.lxdproject.lxd.correctioncomment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class CorrectionCommentRequestDTO {
 
-    @Schema(description = "댓글 내용", example = "정말 좋은 교정이에요!")
-    private Long parentId; // 대댓글일 경우 필요
+    @Schema(description = "부모 댓글 ID (대댓글인 경우 사용)", example = "null")
+    private Long parentId;
+
+    @Schema(description = "댓글 본문", example = "정말 좋은 교정이에요!")
     private String commentText;
 }
+
+
+
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentRequestDTO.java
@@ -1,21 +1,24 @@
 package org.lxdproject.lxd.correctioncomment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "교정 댓글 작성 요청 DTO")
 @Getter
 @Setter
-@NoArgsConstructor
 public class CorrectionCommentRequestDTO {
-
-    @Schema(description = "부모 댓글 ID (대댓글인 경우 사용)", example = "null")
+    @Schema(description = "부모 댓글 ID (대댓글일 경우 사용)", example = "0", nullable = true)
     private Long parentId;
 
+    @NotBlank(message = "댓글 본문은 비어 있을 수 없습니다.")
     @Schema(description = "댓글 본문", example = "정말 좋은 교정이에요!")
     private String commentText;
+
 }
+
+
 
 
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -1,13 +1,17 @@
 package org.lxdproject.lxd.correctioncomment.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CorrectionCommentResponseDTO {
     private Long commentId;
     private int userId;

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -10,11 +10,11 @@ import java.util.List;
 @Builder
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private int memberId;
-    private Long parentId;
+    private int userId;
     private String nickname;
-    private String profileImage; 필요없음
+    private String profileImage;
     private String content;
+    private Long parentId;
     private int likeCount;
     private boolean isLiked;
     private LocalDateTime createdAt;

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private int userId;
+    private Long userId;
     private String nickname;
     private String profileImage;
     private String content;

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -10,12 +10,12 @@ import java.util.List;
 @Builder
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private Long parentId; // 현재 구조에서는 null (확장 시 대댓글 가능)
+    private int memberId;
+    private Long parentId;
     private String nickname;
-    private String profileImage;
+    private String profileImage; 필요없음
     private String content;
     private int likeCount;
-    private boolean isLiked; // 추후 구현->좋아요
+    private boolean isLiked;
     private LocalDateTime createdAt;
 }
-

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
@@ -23,7 +23,7 @@ public class CorrectionComment extends BaseEntity {
 
     // 연관관계: 유저
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     // 연관관계: 교정

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
@@ -22,7 +22,7 @@ public class CorrectionComment extends BaseEntity {
 
     // 연관관계: 유저
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private Member member;
 
     // 연관관계: 교정

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
@@ -37,7 +37,7 @@ public class CorrectionComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
-    private DiaryComment parent; // 대댓글용 자기 참조
+    private CorrectionComment parent;
 
     // 좋아요 수
     @Column(name = "like_count", nullable = false)

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/entity/CorrectionComment.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.correctioncomment.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.lxdproject.lxd.common.entity.BaseEntity;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.correction.entity.Correction;
 
@@ -34,6 +35,10 @@ public class CorrectionComment extends BaseEntity {
     @Column(name = "comment_text", columnDefinition = "TEXT", nullable = false)
     private String commentText;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private DiaryComment parent; // 대댓글용 자기 참조
+
     // 좋아요 수
     @Column(name = "like_count", nullable = false)
     private int likeCount;
@@ -49,7 +54,6 @@ public class CorrectionComment extends BaseEntity {
     }
 
 
-    //baseEntity상속으로 변경
     public String getCommentText() {
         if (isDeleted()) {
             return "삭제된 댓글입니다.";

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface CorrectionCommentRepository extends JpaRepository<CorrectionComment, Long> {
-    Page<CorrectionComment> findAllByCorrectionId(Long correctionId, Pageable pageable);
 
     @Query("SELECT c FROM CorrectionComment c WHERE c.correction.id = :correctionId ORDER BY c.createdAt ASC")
     Page<CorrectionComment> findByCorrectionIdWithOldestFirst(@Param("correctionId") Long correctionId, Pageable pageable);

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -1,9 +1,15 @@
 package org.lxdproject.lxd.correctioncomment.repository;
 
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.apiPayload.code.status.SuccessStatus;
+import org.lxdproject.lxd.config.security.SecurityUtil;
+import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentPageResponseDTO;
 import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,5 +29,6 @@ public interface CorrectionCommentRepository extends JpaRepository<CorrectionCom
     List<CorrectionComment> findByCorrectionIdIn(List<Long> parentIds);
 
     List<CorrectionComment> findByParentIdIn(List<Long> parentIds);
+
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -1,11 +1,26 @@
 package org.lxdproject.lxd.correctioncomment.repository;
 
 import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CorrectionCommentRepository extends JpaRepository<CorrectionComment, Long> {
     Page<CorrectionComment> findAllByCorrectionId(Long correctionId, Pageable pageable);
+
+    @Query("SELECT c FROM CorrectionComment c WHERE c.correction.id = :correctionId ORDER BY c.createdAt ASC")
+    Page<CorrectionComment> findByCorrectionIdWithOldestFirst(@Param("correctionId") Long correctionId, Pageable pageable);
+
+
+    // 부모 댓글 페이징
+    Page<CorrectionComment> findByCorrecionIdAndParentIsNull(Long correctionId, Pageable pageable);
+
+    // 자식 댓글 일괄 조회
+    List<CorrectionComment> findByCorrectionIdIn(List<Long> parentIds);
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -17,7 +17,8 @@ public interface CorrectionCommentRepository extends JpaRepository<CorrectionCom
 
 
     // 부모 댓글 페이징
-    Page<CorrectionComment> findByCorrecionIdAndParentIsNull(Long correctionId, Pageable pageable);
+    Page<CorrectionComment> findByCorrectionIdAndParentIsNull(Long correctionId, Pageable pageable);
+
 
     // 자식 댓글 일괄 조회
     List<CorrectionComment> findByCorrectionIdIn(List<Long> parentIds);

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -30,5 +30,7 @@ public interface CorrectionCommentRepository extends JpaRepository<CorrectionCom
 
     List<CorrectionComment> findByParentIdIn(List<Long> parentIds);
 
+    List<CorrectionComment> findByParentIdInAndIsDeletedFalse(List<Long> parentIds);
+
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -19,8 +19,9 @@ public interface CorrectionCommentRepository extends JpaRepository<CorrectionCom
     // 부모 댓글 페이징
     Page<CorrectionComment> findByCorrectionIdAndParentIsNull(Long correctionId, Pageable pageable);
 
-
     // 자식 댓글 일괄 조회
     List<CorrectionComment> findByCorrectionIdIn(List<Long> parentIds);
+
+    List<CorrectionComment> findByParentIdIn(List<Long> parentIds);
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -1,6 +1,10 @@
 package org.lxdproject.lxd.correctioncomment.service;
 
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.correction.repository.CorrectionRepository;
 import org.lxdproject.lxd.correctioncomment.dto.*;
@@ -11,6 +15,7 @@ import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -21,12 +26,23 @@ public class CorrectionCommentService {
     private final CorrectionCommentRepository commentRepository;
     private final CorrectionRepository correctionRepository;
     private final MemberRepository memberRepository;
+    //like구현필요 likeRepository
 
     public CorrectionCommentResponseDTO createComment(Long correctionId, CorrectionCommentRequestDTO request, Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Correction correction = correctionRepository.findById(correctionId)
-                .orElseThrow(() -> new IllegalArgumentException("교정 없음"));
+                .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_NOT_FOUND));
+
+        CorrectionComment parent = null;
+        if (request.getParentId() != null) {
+            parent = commentRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new CommentHandler(ErrorStatus.PARENT_COMMENT_NOT_FOUND));
+
+            if (parent.getParent() != null) {
+                throw new CommentHandler(ErrorStatus.COMMENT_DEPTH_EXCEEDED);
+            }
+        }
 
         CorrectionComment comment = CorrectionComment.builder()
                 .member(member)
@@ -48,53 +64,45 @@ public class CorrectionCommentService {
                 .build();
     }
 
-    public CorrectionCommentPageResponseDTO getComments(Long correctionId, Pageable pageable) {
-        Page<CorrectionComment> comments = CorrectionCommentRepository.findByCorrectionIdWithOldestFirst(correctionId, pageable);
+    public CorrectionCommentPageResponseDTO getComments(Long correctionId, Long userId, Pageable pageable) {
+        Page<CorrectionComment> comments = commentRepository.findByCorrectionIdWithOldestFirst(correctionId, pageable);
 
         List<CorrectionCommentResponseDTO> content = comments.getContent().stream()
                 .map(comment -> CorrectionCommentResponseDTO.builder()
                         .commentId(comment.getId())
                         .nickname(comment.getMember().getNickname())
-                        .profileImage(comment.getMember().getProfileImage())
+                        .profileImage(comment.getMember().getProfileImg())
                         .content(comment.getCommentText())
-                        .likeCount(comment.getLikes().size())
-                        .isLiked(false) // 좋아요 여부는 일단 false 처리 (추후 로직 필요)
+                        .likeCount(comment.getLikeCount())
+                        .isLiked(false) // 좋아요 여부는 일단 false 처리
                         .createdAt(comment.getCreatedAt())
                         .build()
                 )
                 .toList();
 
         return CorrectionCommentPageResponseDTO.builder()
-                .content(content)
+                .replies(content)
                 .totalElements(comments.getTotalElements())
                 .build();
     }
 
+    @Transactional
+    public CorrectionCommentDeleteResponseDTO deleteComment(Long commentId, Long userId) {
+        CorrectionComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
 
-    public CorrectionCommentPageResponseDTO getComments(Long correctionId, Long memberId, Pageable pageable) {
-        Page<CorrectionComment> comments = CorrectionCommentRepository.findByCorrectionIdWithOldestFirst(correctionId, pageable);
+        if (!comment.getMember().getId().equals(userId)) {
+            throw new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND); // 자신이 쓴 댓글만 삭제 가능
+        }
 
-        List<CorrectionCommentResponseDTO> content = comments.getContent().stream()
-                .map(comment -> CorrectionCommentResponseDTO.builder()
-                        .commentId(comment.getId())
-                        .parentId(null)
-                        .nickname(comment.getMember().getNickname())
-                        .profileImage(comment.getMember().getProfileImage())
-                        .content(comment.getCommentText()) // 삭제된 댓글 처리 포함
-                        .likeCount(comment.getLikes().size())
-                        .isLiked(comment.getLikes().stream()
-                                .anyMatch(like -> like.getMember().getId().equals(memberId)))
-                        .createdAt(comment.getCreatedAt())
-                        .build())
-                .toList();
-
-        return CorrectionCommentPageResponseDTO.builder()
-                .content(content)
-                .totalElements(comments.getTotalElements())
+        comment.softDelete(); // 삭제 시간 세팅
+        return CorrectionCommentDeleteResponseDTO.builder()
+                .commentId(comment.getId())
+                .isDeleted(comment.isDeleted())
+                .content(comment.getCommentText())  // "삭제된 댓글입니다."
+                .deletedAt(comment.getDeletedAt())
                 .build();
     }
-
-
 
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -58,6 +58,7 @@ public class CorrectionCommentService {
                 .nickname(member.getNickname())
                 .profileImage(member.getProfileImg())
                 .content(saved.getCommentText())
+                .parentId(parent != null ? parent.getId() : null)
                 .likeCount(saved.getLikeCount())
                 .isLiked(false)
                 .createdAt(saved.getCreatedAt())

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -5,13 +5,11 @@ import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
-import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.correction.repository.CorrectionRepository;
 import org.lxdproject.lxd.correctioncomment.dto.*;
 import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.lxdproject.lxd.correctioncomment.repository.CorrectionCommentRepository;
-import org.lxdproject.lxd.diarycomment.dto.DiaryCommentRequestDTO;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.data.domain.Page;
@@ -126,7 +124,7 @@ public class CorrectionCommentService {
                     .build();
         }).toList();
 
-        int totalElements = parents.size() + childComments.size();
+        long totalElements = parents.size() + childComments.size();
 
         return CorrectionCommentPageResponseDTO.builder()
                 .replies(result)

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
@@ -6,11 +6,9 @@ import org.lxdproject.lxd.apiPayload.code.status.SuccessStatus;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.diarycomment.dto.*;
 import org.lxdproject.lxd.diarycomment.service.DiaryCommentService;
-import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,7 +32,7 @@ public class DiaryCommentController implements DiaryCommentApi {
     public ApiResponse<DiaryCommentResponseDTO.CommentList> getComments(
             Long diaryId, int page, int size
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
         DiaryCommentResponseDTO.CommentList response =
                 diaryCommentService.getComments(diaryId, pageable);
         return ApiResponse.of(SuccessStatus._OK, response);

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -16,6 +16,7 @@ public class DiaryCommentResponseDTO {
     private String profileImage;
     private String commentText;
     private Long parentId; // nullable
+    private int likeCount;
     private boolean isLiked;
     private LocalDateTime createdAt;
 

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -16,6 +16,7 @@ public class DiaryCommentResponseDTO {
     private String profileImage;
     private String commentText;
     private Long parentId; // nullable
+    private boolean isLiked;
     private LocalDateTime createdAt;
 
     @Getter
@@ -32,8 +33,7 @@ public class DiaryCommentResponseDTO {
         private int likeCount;
         private boolean isLiked;
         private LocalDateTime createdAt;
-        private List<Comment> replies;
-
+        private List<Comment> replies;  //대댓글
     }
 
     @Getter

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -5,6 +5,8 @@ import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,5 +16,8 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
 
     // 자식 댓글 일괄 조회
     List<DiaryComment> findByParentIdIn(List<Long> parentIds);
+
+    @Query("SELECT COUNT(c) FROM DiaryComment c WHERE c.diary.id = :diaryId")
+    long countAllCommentsIncludingDeleted(@Param("diaryId") Long diaryId);
 
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -109,9 +109,11 @@ public class DiaryCommentService {
         List<DiaryCommentResponseDTO.Comment> commentDTOs =
                 DiaryCommentConverter.toCommentDtoTree(parents, repliesGroupedByParent, likedCommentIds);
 
+        int totalElements = parents.size() + allReplies.size();
+
         return DiaryCommentResponseDTO.CommentList.builder()
                 .content(commentDTOs)
-                .totalElements((int) parentComments.getTotalElements())
+                .totalElements(totalElements)
                 .build();
     }
 
@@ -125,6 +127,7 @@ public class DiaryCommentService {
 
         comment.softDelete();
         diary.decreaseCommentCount();
+
 
         return DiaryCommentDeleteResponseDTO.from(comment);
     }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -74,6 +74,7 @@ public class DiaryCommentService {
                 .profileImage(member.getProfileImg())
                 .commentText(saved.getCommentText())
                 .parentId(parent != null ? parent.getId() : null)
+                .isLiked(false)
                 .createdAt(saved.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -74,6 +74,7 @@ public class DiaryCommentService {
                 .profileImage(member.getProfileImg())
                 .commentText(saved.getCommentText())
                 .parentId(parent != null ? parent.getId() : null)
+                .likeCount(saved.getLikeCount())
                 .isLiked(false)
                 .createdAt(saved.getCreatedAt())
                 .build();

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryCommentLikeRepository extends JpaRepository<DiaryCommentLike, Long> {
-    Optional<DiaryCommentLike> findByMemberIdAndComment_Id(Long memberId, Long commentId);
+    Optional<DiaryCommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
+
 
     @Query("SELECT l.comment.id FROM DiaryCommentLike l WHERE l.member.id = :memberId AND l.comment.id IN :commentIds")
     List<Long> findLikedCommentIds(@Param("memberId") Long memberId, @Param("commentIds") List<Long> commentIds);

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
@@ -6,48 +6,53 @@ import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
 import org.lxdproject.lxd.diarycommentlike.dto.DiaryCommentLikeResponseDTO;
 import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
 import org.lxdproject.lxd.diarycommentlike.repository.DiaryCommentLikeRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-
-import static org.lxdproject.lxd.member.entity.QMember.member;
 
 @Service
 @RequiredArgsConstructor
 public class DiaryCommentLikeService {
 
-    private final DiaryCommentLikeRepository likeRepository;
+    private final MemberRepository memberRepository;
     private final DiaryCommentRepository commentRepository;
+    private final DiaryCommentLikeRepository likeRepository;
 
     public DiaryCommentLikeResponseDTO toggleLike(Long memberId, Long diaryId, Long commentId) {
 
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         DiaryComment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
 
         if (!comment.getDiary().getId().equals(diaryId)) {
             throw new IllegalArgumentException("해당 댓글은 지정된 일기에 속하지 않습니다.");
         }
 
-        Optional<DiaryCommentLike> existing = likeRepository.findByMemberIdAndComment_Id(memberId, commentId);
+        Optional<DiaryCommentLike> existing = likeRepository.findByMemberIdAndCommentId(memberId, commentId);
+
         boolean liked;
 
         if (existing.isPresent()) {
-            likeRepository.delete(existing.get());
-            comment.decreaseLikeCount(); // likeCount 감소
+            likeRepository.delete(existing.get());;
+            comment.decreaseLikeCount();
+            commentRepository.save(comment);
             liked = false;
         } else {
             likeRepository.save(
                     DiaryCommentLike.builder()
-                            //.member(memberEntity)
+                            .member(member)
                             .comment(comment)
                             .build()
             );
-            comment.increaseLikeCount(); // likeCount 증가
+            comment.increaseLikeCount();
+            commentRepository.save(comment);
             liked = true;
         }
-
-
-
 
         return DiaryCommentLikeResponseDTO.builder()
                 .commentId(commentId)
@@ -57,5 +62,6 @@ public class DiaryCommentLikeService {
                 .build();
     }
 }
+
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-      active: local
+    active: local


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #117 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
교정 댓글, 일기 댓글, 일기 댓글 좋아요 부분 API를 수정했습니다.

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
-댓글의 totalElement가 부모+자식 댓글의 합이 되도록 수정
-일기 댓글 좋아요 관련 일기 댓글/일기 댓글 좋아요 부분 코드 수정
-교정 댓글 작성/조회/삭제 부분 수정


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 교정 댓글에 대댓글(1단계 답글) 작성 및 조회 기능이 추가되었습니다.
  * 교정 댓글과 일기 댓글에 좋아요 수 및 내가 좋아요를 눌렀는지 여부가 표시됩니다.

* **개선 사항**
  * 교정 댓글 및 일기 댓글 목록의 정렬이 최신순에서 오래된순으로 변경되었습니다.
  * 교정 댓글 작성 시 본문 미입력에 대한 유효성 검사가 강화되었습니다.
  * 교정 댓글 API 문서 및 응답 구조가 개선되어 더 명확한 정보를 제공합니다.
  * 교정 댓글 조회 시 부모 댓글과 자식 댓글을 함께 계층 구조로 반환하도록 개선되었습니다.
  * 교정 댓글 삭제 시 권한 검증과 예외 처리가 강화되었습니다.
  * 일기 댓글 좋아요 기능에서 회원 검증 및 좋아요 수 반영이 정확해졌습니다.

* **버그 수정**
  * 댓글 삭제 시 권한 및 예외 처리가 개선되었습니다.

* **기타**
  * 내부 구조 및 코드 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->