### PR TITLE
[REFACTOR] 내가 제공한 교정 Response 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -61,7 +61,7 @@ public class CorrectionResponseDTO {
         private String thumbImg;
         private String createdAt;
         private String userId;
-        private String userNickname;
+        private String userProfileImg;
 
         public static DiaryInfo from(Diary diary) {
             return DiaryInfo.builder()
@@ -70,7 +70,7 @@ public class CorrectionResponseDTO {
                     .thumbImg(diary.getThumbImg())
                     .createdAt(DateFormatUtil.formatDate(diary.getCreatedAt()))
                     .userId(diary.getMember().getUsername())
-                    .userNickname(diary.getMember().getNickname())
+                    .userProfileImg(diary.getMember().getProfileImg())
                     .build();
         }
     }

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -2,6 +2,10 @@ package org.lxdproject.lxd.correction.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.correction.entity.Correction;
+import org.lxdproject.lxd.correction.util.DateFormatUtil;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.member.entity.Member;
 
 import java.util.List;
 
@@ -38,21 +42,69 @@ public class CorrectionResponseDTO {
         private String userId;
         private String nickname;
         private String profileImageUrl;
+
+        public static MemberInfo from(Member member) {
+            return MemberInfo.builder()
+                    .memberId(member.getId())
+                    .userId(member.getUsername())
+                    .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImg())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DiaryInfo {
+        private Long diaryId;
+        private String title;
+        private String thumbImg;
+        private String createdAt;
+        private String userId;
+        private String userNickname;
+
+        public static DiaryInfo from(Diary diary) {
+            return DiaryInfo.builder()
+                    .diaryId(diary.getId())
+                    .title(diary.getTitle())
+                    .thumbImg(diary.getThumbImg())
+                    .createdAt(DateFormatUtil.formatDate(diary.getCreatedAt()))
+                    .userId(diary.getMember().getUsername())
+                    .userNickname(diary.getMember().getNickname())
+                    .build();
+        }
     }
 
     @Getter
     @Builder
     public static class ProvidedCorrectionItem {
         private Long correctionId;
-        private Long diaryId;
-        private String diaryTitle;
-        private String diaryCreatedAt;
         private String createdAt;
         private String originalText;
         private String corrected;
         private String commentText;
         private Integer commentCount;
         private Integer likeCount;
+        private DiaryInfo diaryInfo;
+
+        public static ProvidedCorrectionItem from(Correction correction) {
+            Diary diary = correction.getDiary();
+
+            DiaryInfo diaryInfo = (diary == null || diary.isDeleted())
+                    ? null
+                    : DiaryInfo.from(diary);
+
+            return ProvidedCorrectionItem.builder()
+                    .correctionId(correction.getId())
+                    .createdAt(DateFormatUtil.formatDate(correction.getCreatedAt()))
+                    .originalText(correction.getOriginalText())
+                    .corrected(correction.getCorrected())
+                    .commentText(correction.getCommentText())
+                    .commentCount(correction.getCommentCount())
+                    .likeCount(correction.getLikeCount())
+                    .diaryInfo(diaryInfo)
+                    .build();
+        }
     }
 
     @Getter
@@ -62,10 +114,24 @@ public class CorrectionResponseDTO {
         private List<ProvidedCorrectionItem> corrections;
         private int page;
         private int size;
-        private int totalCount;
         private boolean hasNext;
-    }
 
+        public static ProvidedCorrectionsResponseDTO from(
+                Member member,
+                List<ProvidedCorrectionItem> corrections,
+                int page,
+                int size,
+                boolean hasNext
+        ) {
+            return ProvidedCorrectionsResponseDTO.builder()
+                    .member(MemberInfo.from(member))
+                    .corrections(corrections)
+                    .page(page)
+                    .size(size)
+                    .hasNext(hasNext)
+                    .build();
+        }
+    }
 
     @Getter
     @Builder

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -163,36 +163,19 @@ public class CorrectionService {
         Member member = memberRepository.findById(SecurityUtil.getCurrentMemberId())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-
         Slice<Correction> corrections = correctionRepository.findByAuthor(member, pageable);
 
-        List<CorrectionResponseDTO.ProvidedCorrectionItem> correctionItems = corrections.getContent().stream()
-                .map(correction -> CorrectionResponseDTO.ProvidedCorrectionItem.builder()
-                        .correctionId(correction.getId())
-                        .diaryId(correction.getDiary().getId())
-                        .diaryTitle(correction.getDiary().getTitle())
-                        .diaryCreatedAt(DateFormatUtil.formatDate(correction.getDiary().getCreatedAt()))
-                        .createdAt(DateFormatUtil.formatDate(correction.getCreatedAt()))
-                        .originalText(correction.getOriginalText())
-                        .corrected(correction.getCorrected())
-                        .commentText(correction.getCommentText())
-                        .likeCount(correction.getLikeCount())
-                        .commentCount(correction.getCommentCount())
-                        .build())
+        List<CorrectionResponseDTO.ProvidedCorrectionItem> items = corrections.getContent().stream()
+                .map(CorrectionResponseDTO.ProvidedCorrectionItem::from)
                 .toList();
 
-        return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
-                .member(CorrectionResponseDTO.MemberInfo.builder()
-                        .memberId(member.getId())
-                        .userId(member.getUsername())
-                        .nickname(member.getNickname())
-                        .profileImageUrl(member.getProfileImg())
-                        .build())
-                .corrections(correctionItems)
-                .page(page)
-                .size(size)
-                .hasNext(corrections.hasNext())
-                .build();
+        return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.from(
+                member,
+                items,
+                page,
+                size,
+                corrections.hasNext()
+        );
     }
 
     private CorrectionResponseDTO.DiaryCorrectionsResponseDTO emptyDiaryCorrectionsResponse(Long diaryId) {


### PR DESCRIPTION
## 📌 Issue number and Link
closed #135 

## ✏️ Summary
내가 제공한 교정 내 일기 response를 추가합니다.

## 📝 Changes
- 일기 response 추가
- dto memberInfo, diaryInfo, correction으로 분리 

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 제공한 첨삭 목록에서 일기 정보(제목, 썸네일, 작성일, 작성자 등)를 하나의 정보로 묶어 확인할 수 있습니다.

* **리팩터**
  * 첨삭 및 일기 정보 구성이 개선되어, 더 일관성 있고 보기 쉽게 변경되었습니다.  
  * DTO 생성 방식이 표준화되어 코드의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->