### PR TITLE
[FEATURE] 다른 사용자의 일기 정보 요약 API의 반환값 dto에 FriendRequestStatus enum 내용 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
@@ -101,14 +101,14 @@ public class DiaryController implements DiaryApi{
     @Override
     public ApiResponse<MemberDiarySummaryResponseDTO> getMyDiarySummary() {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        MemberDiarySummaryResponseDTO response = diaryService.getDiarySummary(currentMemberId, currentMemberId);
+        MemberDiarySummaryResponseDTO response = diaryService.getDiarySummary(currentMemberId, currentMemberId, false);
         return ApiResponse.onSuccess(response);
     }
 
     @Override
     public ApiResponse<MemberDiarySummaryResponseDTO> getUserDiarySummary(Long memberId) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        MemberDiarySummaryResponseDTO response = diaryService.getDiarySummary(memberId, currentMemberId);
+        MemberDiarySummaryResponseDTO response = diaryService.getDiarySummary(memberId, currentMemberId, true);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
@@ -1,5 +1,6 @@
 package org.lxdproject.lxd.diary.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import org.lxdproject.lxd.diary.entity.enums.RelationType;
@@ -14,5 +15,7 @@ public class MemberDiarySummaryResponseDTO {
     private Long diaryCount;
     private Integer friendCount;
     private RelationType relation;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private FriendRequestStatus status;
 }

--- a/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diary.dto;
 import lombok.Builder;
 import lombok.Getter;
 import org.lxdproject.lxd.diary.entity.enums.RelationType;
+import org.lxdproject.lxd.member.entity.enums.FriendRequestStatus;
 
 @Getter
 @Builder
@@ -13,4 +14,5 @@ public class MemberDiarySummaryResponseDTO {
     private Long diaryCount;
     private Integer friendCount;
     private RelationType relation;
+    private FriendRequestStatus status;
 }

--- a/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
@@ -16,6 +16,6 @@ public class MemberDiarySummaryResponseDTO {
     private Integer friendCount;
     private RelationType relation;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값도 반환하려면 이 부분 주석처리하면 됨
     private FriendRequestStatus status;
 }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #141 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

-  다른 사용자의 일기 정보 요약 API의 반환값 dto에 FriendRequestStatus enum 내용 추가

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- `DiaryService`, `MemberDiarySummaryResponseDTO`, ...

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 일기 요약 응답에 친구 요청 상태 정보가 추가되었습니다. 이제 다른 사용자의 일기 요약을 조회할 때 친구 요청 상태를 확인할 수 있습니다.  
* **버그 수정**
  * 없음  
* **리팩터**
  * 일기 요약 조회 시 추가적인 파라미터로 상태 정보를 포함할지 선택할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->