### PR TITLE
[FEATURE] 친구 목록 조회 API, 친구 요청 목록 조회 API에 각각 친구수, 요청수 필드 동일하게 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/member/dto/FriendListResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/FriendListResponseDTO.java
@@ -9,5 +9,6 @@ import java.util.List;
 @AllArgsConstructor
 public class FriendListResponseDTO {
     private int totalFriends;
+    private int totalRequests;
     private List<FriendResponseDTO> friends;
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/FriendRequestListResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/FriendRequestListResponseDTO.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class FriendRequestListResponseDTO {
     private int sentRequestsCount;
     private int receivedRequestsCount;
+    private int totalFriends;
     private List<FriendResponseDTO> sentRequests;
     private List<FriendResponseDTO> receivedRequests;
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -3,9 +3,7 @@ package org.lxdproject.lxd.member.service;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
-import org.lxdproject.lxd.diary.dto.MyDiarySummaryResponseDTO;
-import org.lxdproject.lxd.diary.entity.Diary;
-import org.lxdproject.lxd.diary.repository.DiaryRepository;
+
 import org.lxdproject.lxd.member.dto.*;
 import org.lxdproject.lxd.member.entity.FriendRequest;
 import org.lxdproject.lxd.member.entity.Member;
@@ -16,9 +14,6 @@ import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.lxdproject.lxd.diary.util.DiaryUtil.generateContentPreview;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #134

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- 친구 목록 조회 API, 친구 요청 목록 조회 API에 각각 친구수, 요청수 필드 동일하게 추가

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- `FriendRequestListResponseDTO`, `FriendListResponseDTO`, `FriendService` , ...

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 친구 목록 조회 시 전체 친구 요청 수(totalRequests)와 전체 친구 수(totalFriends) 정보를 추가로 확인할 수 있습니다.
  * 친구 요청 목록 조회 시 전체 친구 수(totalFriends) 정보를 추가로 확인할 수 있습니다.

* **Refactor**
  * 내부 코드 구조가 개선되어 서비스의 안정성과 유지보수성이 향상되었습니다. (이용자 경험에는 직접적인 영향 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->