### PR TITLE
[FIX] 이메일 전송 API 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -55,6 +55,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 메일 관련 에러
     UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL 4301", "이메일을 보낼 수 없습니다."),
+    INVALID_EMAIL_TOKEN(HttpStatus.UNAUTHORIZED, "EMAIL4311", "이메일 인증 토큰이 유효하지 않습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,"NOTIFICATION4001","알림을 찾을 수 없습니다."),

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -61,6 +61,7 @@ public interface AuthApi {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 실패 또는 파라미터 오류"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 이메일 토큰"),
     })
     ApiResponse<AuthResponseDTO.GetEmailByTokenResponseDTO> getEmailByToken(@RequestParam ("token") String token);
 

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.auth.dto.AuthRequestDTO;
 import org.lxdproject.lxd.auth.dto.AuthResponseDTO;
@@ -59,11 +60,14 @@ public interface AuthApi {
     @GetMapping("/email")
     @Operation(summary = "이메일 인증 시 프론트엔드 uri에 전달한 토큰의 주인(이메일)을 반환합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 실패 또는 파라미터 오류"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 이메일 토큰"),
     })
-    ApiResponse<AuthResponseDTO.GetEmailByTokenResponseDTO> getEmailByToken(@RequestParam ("token") String token);
+    ApiResponse<AuthResponseDTO.GetEmailByTokenResponseDTO> getEmailByToken(
+            @Parameter(description = "이메일 인증 토큰", required = true, example = "abc123token")
+            @RequestParam("token") @NotBlank String token
+    );
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급 API", description = "access token 및 refresh token 재발급 기능입니다.")

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -56,6 +56,14 @@ public interface AuthApi {
     })
     ApiResponse<AuthResponseDTO.SocialLoginResponseDTO> loginWithGoogle(@RequestBody AuthRequestDTO.SocialLoginRequestDTO socialLoginRequestDTO);
 
+    @GetMapping("/email")
+    @Operation(summary = "이메일 인증 시 프론트엔드 uri에 전달한 토큰의 주인(이메일)을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 실패 또는 파라미터 오류"),
+    })
+    ApiResponse<AuthResponseDTO.GetEmailByTokenResponseDTO> getEmailByToken(@RequestParam ("token") String token);
+
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급 API", description = "access token 및 refresh token 재발급 기능입니다.")
     @ApiResponses({

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthController.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthController.java
@@ -53,6 +53,14 @@ public class AuthController implements AuthApi {
     }
 
     @Override
+    public ApiResponse<AuthResponseDTO.GetEmailByTokenResponseDTO> getEmailByToken(String token) {
+
+        AuthResponseDTO.GetEmailByTokenResponseDTO getEmailByTokenResponseDTO = authService.getEmailByToken(token);
+
+        return ApiResponse.onSuccess(getEmailByTokenResponseDTO);
+    }
+
+    @Override
     public ApiResponse<AuthResponseDTO.ReissueResponseDTO> reissue(@RequestBody @Valid AuthRequestDTO.ReissueRequestDTO reissueRequestDTO) {
 
         AuthResponseDTO.ReissueResponseDTO reissueResponseDTO = authService.reissue(reissueRequestDTO);

--- a/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
@@ -121,4 +121,15 @@ public class AuthResponseDTO {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetEmailByTokenResponseDTO {
+
+        @Schema(description = "이메일")
+        private String email;
+
+    }
+
 }

--- a/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
@@ -234,4 +234,17 @@ public class AuthService {
         redisService.deleteValues(refreshToken);
 
     }
+
+    public AuthResponseDTO.GetEmailByTokenResponseDTO getEmailByToken(String token) {
+
+        String email = redisService.getValues(token);
+
+        if(email == null) {
+            throw new AuthHandler(ErrorStatus.INVALID_EMAIL_TOKEN);
+        }
+
+        return AuthResponseDTO.GetEmailByTokenResponseDTO.builder()
+                .email(email)
+                .build();
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
@@ -129,7 +129,12 @@ public class AuthService {
                 response.sendRedirect(urlProperties.getFrontend() + "/email-verification/fail");
             } else {
                 redisService.deleteValues(token); // 재사용 방지
-                response.sendRedirect(urlProperties.getFrontend() + "/email-verification/success");
+
+                String newToken = createSecureToken();
+                redisService.setValues(newToken, email, Duration.ofMinutes(1L));
+
+                //TODO 임시적으로 프론트엔드 uri를 하드코딩 방식으로 구현했어서 추후 urlProperties.getFrontend() 방식으로 변경하기
+                response.sendRedirect("http://localhost:5173" + "/signup?token=" +newToken );
             }
         }catch (IOException e) {
             log.error("redirect에 실패했습니다");

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
             "/auth/google/login",
             "/auth/emails/verification-requests",
             "/auth/emails/verifications",
+            "/auth/email",
+            "/auth/email/**", // 쿼리 파라미터가 있는 경우 /** uri 추가로 붙여주기
             "/auth/reissue",
             "/auth/logout"
     };


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #153 

## ✏️ Summary
프론트엔드의 요청사항에 따라 이메일 인증 API를 수정했습니다.

## 📝 Changes
- 인증 링크 클릭 시 리다이렉트 링크를 프론트엔드 uri + 'signup?token=xxx' 주소로 변경했습니다.
  ⚠️ 빠른 연동 테스트를 위해 프론트엔드 uri를 하드코딩으로 적어서 추후 @Value 값으로 수정이 필요합니다.
- 이메일 인증 토큰을 입력 시 이메일을 알려주는 api를 구현했습니다.
  ⚠️ SecurityConfig에 화이트리스트 등록 시 쿼리 파라미터가 있는 경우 원래 uri 와 원래 uri + '/**' 2개를 붙여야 오류가 없음을 확인했습니다. 이 부분은 추후에 AccessDeniedHandler 도입 등을 통해 수정 해보겠습니다.


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 인증 토큰을 이용해 이메일 정보를 반환하는 새로운 API 엔드포인트(/auth/email)가 추가되었습니다.
  * 이메일 토큰이 유효하지 않을 경우의 에러 메시지가 추가되었습니다.

* **버그 수정**
  * 이메일 인증 후 리디렉션 방식이 개선되어, 인증 성공 시 1분간 유효한 토큰이 발급되고 해당 토큰이 포함된 프론트엔드 회원가입 페이지로 이동합니다.

* **보안**
  * /auth/email 경로가 인증 없이 접근 가능한 경로에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->