### PR TITLE
[FIX] 알림 구독시 readState가 1로 바뀌지 않는 에러 해결

### DIFF
--- a/src/main/java/org/lxdproject/lxd/notification/service/SseEmitterService.java
+++ b/src/main/java/org/lxdproject/lxd/notification/service/SseEmitterService.java
@@ -21,13 +21,23 @@ public class SseEmitterService {
     public SseEmitter connect() {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        SseEmitter emitter = new SseEmitter(60 * 60 * 1000L); // 3600초 = 1시간 동안 연결 유지
+        SseEmitter emitter = new SseEmitter(60 * 60 * 1000L); // 1시간
         emitters.put(memberId, emitter);
 
         // 연결 종료 시 제거
         emitter.onCompletion(() -> emitters.remove(memberId));
         emitter.onTimeout(() -> emitters.remove(memberId));
         emitter.onError(e -> emitters.remove(memberId));
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("connected")
+            );
+        } catch (IOException e) {
+            emitters.remove(memberId);
+            emitter.completeWithError(e);
+        }
 
         return emitter;
     }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #156 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
연결 직후 더미 이벤트 전송 → 브라우저에서 readyState가 1로 바뀌도록 유도

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSE 연결 시 "connected"라는 초기 이벤트가 즉시 전송되어 실시간 알림 연결 상태를 확인할 수 있습니다.

* **Bug Fixes**
  * 초기 이벤트 전송 중 오류 발생 시 연결이 안전하게 종료되어 예기치 않은 동작을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->