### PR TITLE
[FIX] 이메일 인증 후 redirect되는 uri 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
@@ -131,9 +131,9 @@ public class AuthService {
                 redisService.deleteValues(token); // 재사용 방지
 
                 String newToken = createSecureToken();
-                redisService.setValues(newToken, email, Duration.ofMinutes(1L));
+                redisService.setValues(newToken, email, Duration.ofMinutes(3L));
                 
-                response.sendRedirect(urlProperties.getFrontend() + "/signup?token=" +newToken );
+                response.sendRedirect(urlProperties.getFrontend() + "/home/signup?token=" +newToken );
             }
         }catch (IOException e) {
             log.error("redirect에 실패했습니다");


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #153 

## ✏️ Summary
이메일 인증 후 redirect되는 uri 수정

## 📝 Changes
'http://localhost:5173/signup?token=xxx'  -> 'http://localhost:5173/home/signup?token=xxx' 

## 🔎 PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
