### PR TITLE
[FEATURE] 일기 좋아요 설정/해제 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
             "/test/**",
             "/members/join",
             "/members/check-username",
+            "/members/check-username/**", // 쿼리 파라미터가 있는 경우 /** uri 추가로 붙여주기
             "/members/password-verify",
             "/swagger-ui/**",
             "/v3/api-docs/**",

--- a/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeApi.java
@@ -1,7 +1,30 @@
 package org.lxdproject.lxd.diarylike.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diarylike.dto.DiaryLikeResponseDTO;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
+
+@Tag(name = "Diary Like", description = "일기 좋아요 관련 API 입니다.")
+@RequestMapping("/diaries")
 public interface DiaryLikeApi {
 
-
+    @PostMapping("/{diaryId}/likes")
+    @Operation(summary = "일기 좋아요 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일기 좋아요 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 리소스입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO> toggleDiaryLike(
+            @Parameter(description = "일기 ID") @PathVariable Long diaryId
+    );
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeApi.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.diarylike.controller;
+
+
+public interface DiaryLikeApi {
+
+
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
@@ -1,9 +1,25 @@
 package org.lxdproject.lxd.diarylike.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.diarylike.dto.DiaryLikeResponseDTO;
+import org.lxdproject.lxd.diarylike.service.DiaryLikeService;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
+@RequiredArgsConstructor
+@Validated
 public class DiaryLikeController implements DiaryLikeApi {
 
+    private final DiaryLikeService diaryLikeService;
+
+    @Override
+    public ApiResponse<DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO> toggleDiaryLike(Long diaryId) {
+
+        DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO toggleDiaryLikeResponseDTO = diaryLikeService.toggleDiaryLike(diaryId);
+        return ApiResponse.onSuccess(toggleDiaryLikeResponseDTO);
+
+    }
 
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
@@ -1,0 +1,9 @@
+package org.lxdproject.lxd.diarylike.controller;
+
+import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.diarylike.dto.DiaryLikeResponseDTO;
+
+public class DiaryLikeController implements DiaryLikeApi {
+
+
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/controller/DiaryLikeController.java
@@ -5,6 +5,7 @@ import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.diarylike.dto.DiaryLikeResponseDTO;
 import org.lxdproject.lxd.diarylike.service.DiaryLikeService;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,7 +16,7 @@ public class DiaryLikeController implements DiaryLikeApi {
     private final DiaryLikeService diaryLikeService;
 
     @Override
-    public ApiResponse<DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO> toggleDiaryLike(Long diaryId) {
+    public ApiResponse<DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO> toggleDiaryLike(@PathVariable Long diaryId) {
 
         DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO toggleDiaryLikeResponseDTO = diaryLikeService.toggleDiaryLike(diaryId);
         return ApiResponse.onSuccess(toggleDiaryLikeResponseDTO);

--- a/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeRequestDTO.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.diarylike.dto;
+
+public class DiaryLikeRequestDTO {
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
@@ -1,0 +1,9 @@
+package org.lxdproject.lxd.diarylike.dto;
+
+
+
+public class DiaryLikeResponseDTO {
+
+
+
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
@@ -1,9 +1,31 @@
 package org.lxdproject.lxd.diarylike.dto;
 
-
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class DiaryLikeResponseDTO {
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ToggleDiaryLikeResponseDTO {
 
+        @Schema(description = "일기 ID")
+        private Long diaryId;
+
+        @Schema(description = "좋아요를 누른 사용자 ID")
+        private Long memberId;
+
+        @Schema(description = "좋아요 상태")
+        private Boolean liked;
+
+        @Schema(description = "해당 일기의 좋아요 수")
+        private Integer likedCount;
+
+    }
 
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
@@ -17,10 +17,10 @@ public class DiaryLikeResponseDTO {
         @Schema(description = "일기 ID")
         private Long diaryId;
 
-        @Schema(description = "좋아요를 누른 사용자 ID")
+        @Schema(description = "좋아요를 누르거나 해제한 사용자 ID")
         private Long memberId;
 
-        @Schema(description = "좋아요 상태")
+        @Schema(description = "좋아요 상태, 결과가 좋아요 해제되었으면 false / 결과가 좋아요가 생성되었으면 true ")
         private Boolean liked;
 
         @Schema(description = "해당 일기의 좋아요 수")

--- a/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
@@ -1,0 +1,7 @@
+package org.lxdproject.lxd.diarylike.repository;
+
+import org.lxdproject.lxd.diarylike.entity.DiaryLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryLikeRepository extends JpaRepository<DiaryLike, Long> {
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
@@ -1,7 +1,14 @@
 package org.lxdproject.lxd.diarylike.repository;
 
+import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.diarylike.entity.DiaryLike;
+import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DiaryLikeRepository extends JpaRepository<DiaryLike, Long> {
+
+    Optional<DiaryLike> findByMemberAndDiary(Member member, Diary diary);
+
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
@@ -1,4 +1,7 @@
 package org.lxdproject.lxd.diarylike.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class DiaryLikeService {
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
@@ -1,0 +1,4 @@
+package org.lxdproject.lxd.diarylike.service;
+
+public class DiaryLikeService {
+}

--- a/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
@@ -1,7 +1,70 @@
 package org.lxdproject.lxd.diarylike.service;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.config.security.SecurityUtil;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.repository.DiaryRepository;
+import org.lxdproject.lxd.diarylike.dto.DiaryLikeResponseDTO;
+import org.lxdproject.lxd.diarylike.entity.DiaryLike;
+import org.lxdproject.lxd.diarylike.repository.DiaryLikeRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class DiaryLikeService {
+
+    private final DiaryLikeRepository diaryLikeRepository;
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+
+    public DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO toggleDiaryLike(Long diaryId) {
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() ->  new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+        DiaryLike diaryLike = diaryLikeRepository.findByMemberAndDiary(member, diary)
+                .orElse(null);
+
+        Boolean liked;
+
+        // 기존에 사용자가 좋아요를 한 경우 (좋아요 취소)
+        if(diaryLike != null) {
+            diaryLikeRepository.delete(diaryLike);
+
+            diary.decreaseLikeCount();
+            liked = Boolean.FALSE;
+
+        }else{ // 기존에 사용자가 좋아요를 하지 않은 경우 (좋아요)
+            DiaryLike newDiaryLike = DiaryLike.builder()
+                    .member(member)
+                    .diary(diary)
+                    .build();
+
+            diaryLikeRepository.save(newDiaryLike);
+
+            diary.increaseLikeCount();
+            liked = Boolean.TRUE;
+
+        }
+
+        return DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO.builder()
+                .diaryId(diaryId)
+                .memberId(memberId)
+                .liked(liked)
+                .likedCount(diary.getLikeCount())
+                .build();
+
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/members")
 public interface MemberApi {
 
-    @PostMapping(value = "/join", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/join", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "회원가입 api", description = "계정 생성")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #164 

## ✏️ Summary
일기 좋아요/해제 기능 구현

## 📝 Changes
- 일기 좋아요/해제 기능 구현
- WHITELIST 값 추가
- 회원가입 API에 'MediaType.APPLICATION_JSON' 제거


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 다이어리 좋아요 토글 API가 추가되어, 사용자가 다이어리의 좋아요 상태를 변경할 수 있습니다.
  * 다이어리 좋아요 상태 및 좋아요 수를 반환하는 응답이 제공됩니다.

* **버그 수정**
  * "/members/check-username/**" 경로가 인증 없이 접근 가능하도록 허용되어, 다양한 쿼리 파라미터 케이스를 지원합니다.

* **기타 변경**
  * 회원 가입 API가 이제 multipart form data만 허용하도록 변경되었습니다. JSON 형식의 요청은 더 이상 지원되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->