### PR TITLE
[FIX] 친구 도메인 API 저장 및 조회 방식 통일

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
@@ -13,7 +13,7 @@ public class MemberDiarySummaryResponseDTO {
     private String username;
     private String nickname;
     private Long diaryCount;
-    private Integer friendCount;
+    private Long friendCount;
     private RelationType relation;
 
     @JsonInclude(JsonInclude.Include.NON_NULL) // null 값도 반환하려면 이 부분 주석처리하면 됨

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -193,8 +193,7 @@ public class DiaryService {
 
         Long diaryCount = diaryRepository.countByMemberId(targetMemberId);
 
-        List<Member> friends = friendRepository.findFriendsByMemberId(targetMemberId);
-        Integer friendCount = friends.size();
+        Long friendCount = friendRepository.countFriendsByMemberId(targetMemberId);
 
         RelationType relation;
         if (targetMemberId.equals(currentMemberId)) {

--- a/src/main/java/org/lxdproject/lxd/member/controller/FriendApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/FriendApi.java
@@ -1,6 +1,7 @@
 package org.lxdproject.lxd.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,7 +22,10 @@ public interface FriendApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @GetMapping()
-    ApiResponse<FriendListResponseDTO> getFriendList();
+    ApiResponse<FriendListResponseDTO> getFriendList(
+            @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1") @RequestParam(defaultValue = "1") int page,
+            @Parameter(description = "한 페이지에 포함할 교정 개수", example = "10") @RequestParam(defaultValue = "10") int size
+    );
 
     @Operation(summary = "친구 요청 보내기 API", description = "receiverId를 전달받아 친구 요청을 보냅니다. 상태는 PENDING으로 저장됩니다.")
     @ApiResponses({
@@ -63,7 +67,11 @@ public interface FriendApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @GetMapping("/requests")
-    ApiResponse<FriendRequestListResponseDTO> getFriendRequestList();
+    ApiResponse<FriendRequestListResponseDTO> getFriendRequestList(
+            @Parameter(description = "내가 받은 요청 페이지 번호 (1부터 시작)", example = "1") @RequestParam(defaultValue = "1") int receivedPage,
+            @Parameter(description = "내가 보낸 요청 페이지 번호 (1부터 시작)", example = "1") @RequestParam(defaultValue = "1") int sentPage,
+            @Parameter(description = "한 페이지에 포함할 교정 개수", example = "10") @RequestParam(defaultValue = "10") int size
+    );
 
     @Operation(summary = "친구 요청 거절 API", description = "자신에게 온 친구 요청을 거절합니다.")
     @ApiResponses({

--- a/src/main/java/org/lxdproject/lxd/member/controller/FriendController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/FriendController.java
@@ -5,6 +5,8 @@ import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.member.dto.*;
 import org.lxdproject.lxd.member.service.FriendService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +19,10 @@ public class FriendController implements FriendApi {
     private final FriendService friendService;
 
     @Override
-    public ApiResponse<FriendListResponseDTO> getFriendList() {
+    public ApiResponse<FriendListResponseDTO> getFriendList(int page, int size) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        FriendListResponseDTO response = friendService.getFriendList(currentMemberId);
+        Pageable pageable = PageRequest.of(page - 1, size);
+        FriendListResponseDTO response = friendService.getFriendList(currentMemberId, pageable);
         return ApiResponse.onSuccess(response);
     }
 
@@ -45,9 +48,11 @@ public class FriendController implements FriendApi {
     }
 
     @Override
-    public ApiResponse<FriendRequestListResponseDTO> getFriendRequestList() {
+    public ApiResponse<FriendRequestListResponseDTO> getFriendRequestList(int receivedPage, int sentPage, int size) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        FriendRequestListResponseDTO response = friendService.getPendingFriendRequests(currentMemberId);
+        Pageable sentPageable = PageRequest.of(sentPage - 1, size);
+        Pageable receivedPageable = PageRequest.of(receivedPage - 1, size);
+        FriendRequestListResponseDTO response = friendService.getPendingFriendRequests(currentMemberId, receivedPageable, sentPageable);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/dto/FriendListResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/FriendListResponseDTO.java
@@ -2,13 +2,13 @@ package org.lxdproject.lxd.member.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.PageResponse;
 
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class FriendListResponseDTO {
-    private int totalFriends;
     private int totalRequests;
-    private List<FriendResponseDTO> friends;
+    private PageResponse<FriendResponseDTO> friends;
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/FriendRequestListResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/FriendRequestListResponseDTO.java
@@ -2,15 +2,14 @@ package org.lxdproject.lxd.member.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.PageResponse;
 
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class FriendRequestListResponseDTO {
-    private int sentRequestsCount;
-    private int receivedRequestsCount;
-    private int totalFriends;
-    private List<FriendResponseDTO> sentRequests;
-    private List<FriendResponseDTO> receivedRequests;
+    private Long totalFriends;
+    private PageResponse<FriendResponseDTO> sentRequests;
+    private PageResponse<FriendResponseDTO> receivedRequests;
 }

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface FriendRepository {
     List<Member> findFriendsByMemberId(Long memberId);
-    boolean existsByRequesterAndReceiverOrReceiverAndRequester(Member m1, Member m2);
+    boolean existsFriendshipByRequesterAndReceiver(Member m1, Member m2);
     void saveFriendship(Member requester, Member receiver);
     void softDeleteFriendship(Member m1, Member m2);
     boolean existsFriendRelation(Long memberId, Long friendId);

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRepository.java
@@ -1,11 +1,14 @@
 package org.lxdproject.lxd.member.repository;
 
 import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface FriendRepository {
-    List<Member> findFriendsByMemberId(Long memberId);
+    Page<Member> findFriendsByMemberId(Long memberId, Pageable pageable);
+    long countFriendsByMemberId(Long memberId);
     boolean existsFriendshipByRequesterAndReceiver(Member m1, Member m2);
     void saveFriendship(Member requester, Member receiver);
     void softDeleteFriendship(Member m1, Member m2);

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
@@ -32,9 +32,7 @@ public class FriendRepositoryImpl implements FriendRepository {
     // 1. 친구 관계 조회 <read>  → 단방향 조회
     @Override
     public Page<Member> findFriendsByMemberId(Long memberId, Pageable pageable) { // 친구 목록 반환
-        List<Member> result = new ArrayList<>();
-
-        result.addAll(queryFactory
+        List<Member> result = queryFactory
                 .select(friendship.receiver)
                 .from(friendship)
                 .where(
@@ -43,7 +41,7 @@ public class FriendRepositoryImpl implements FriendRepository {
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetch());
+                .fetch();
 
         long total = queryFactory
                 .select(friendship.count())

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
@@ -25,7 +25,7 @@ public class FriendRepositoryImpl implements FriendRepository {
     private static final QMember requester = new QMember("requester");
     private static final QMember receiver = new QMember("receiver");
 
-    // [1] FriendShip → create, delete, update 양방향, read 단방향
+    // create, delete, update 양방향, read 단방향
     // 1. 친구 관계 조회 <read>  → 단방향 조회
     @Override
     public List<Member> findFriendsByMemberId(Long memberId) { // 친구 목록 반환

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRepositoryImpl.java
@@ -27,10 +27,8 @@ public class FriendRepositoryImpl implements FriendRepository {
 
     @Override
     public List<Member> findFriendsByMemberId(Long memberId) {
-        // union으로 쿼리 한 번에 조회
         List<Member> friends = new ArrayList<>();
-
-        // 내가 요청자인 경우
+        // 단방향 요청으로 수정
         friends.addAll(queryFactory
                 .select(friendship.receiver)
                 .from(friendship)
@@ -39,17 +37,6 @@ public class FriendRepositoryImpl implements FriendRepository {
                         friendship.deletedAt.isNull()
                 )
                 .fetch());
-
-        // 내가 수신자인 경우
-        friends.addAll(queryFactory
-                .select(friendship.requester)
-                .from(friendship)
-                .where(
-                        friendship.receiver.id.eq(memberId),
-                        friendship.deletedAt.isNull()
-                )
-                .fetch());
-
         return friends;
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/repository/FriendRequestRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/FriendRequestRepository.java
@@ -3,6 +3,8 @@ package org.lxdproject.lxd.member.repository;
 import org.lxdproject.lxd.member.entity.FriendRequest;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.member.entity.enums.FriendRequestStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,6 +15,9 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     Optional<FriendRequest> findByRequesterIdAndReceiverId(Long requesterId, Long receiverId);
     Optional<FriendRequest> findByRequesterIdAndReceiverIdAndStatus(Long requesterId, Long receiverId, FriendRequestStatus status);
 
-    List<FriendRequest> findByRequesterAndStatus(Member requester, FriendRequestStatus status);
-    List<FriendRequest> findByReceiverAndStatus(Member receiver, FriendRequestStatus status);
+    int countByRequesterAndStatus(Member requester, FriendRequestStatus status);
+    int countByReceiverAndStatus(Member receiver, FriendRequestStatus status);
+
+    Page<FriendRequest> findByRequesterAndStatus(Member requester, FriendRequestStatus status, Pageable pageable);
+    Page<FriendRequest> findByReceiverAndStatus(Member receiver, FriendRequestStatus status, Pageable pageable);
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -110,7 +110,6 @@ public class FriendService {
         Member requester = request.getRequester();
         Member receiver = request.getReceiver();
         friendRepository.saveFriendship(requester, receiver);
-        friendRepository.saveFriendship(receiver, requester);
 
         friendRequestRepository.delete(request);
 

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -59,7 +59,7 @@ public class FriendService {
 
         boolean alreadyRequested = friendRequestRepository.existsByRequesterAndReceiverAndStatus(
                 requester, receiver, FriendRequestStatus.PENDING);
-        // 양방향 친구 요청 확인 추가
+
         boolean reverseRequested = friendRequestRepository.existsByRequesterAndReceiverAndStatus(
                 receiver, requester, FriendRequestStatus.PENDING);
         if (alreadyRequested || reverseRequested) {
@@ -80,43 +80,17 @@ public class FriendService {
         friendRequestRepository.save(friendRequest);
     }
 
-//    public void acceptFriendRequest(Long receiverId, FriendRequestAcceptRequestDTO requestDto) {
-//        Long requesterId = requestDto.getRequesterId();
-//
-//        if (receiverId.equals(requesterId)) {
-//            throw new FriendHandler(ErrorStatus.INVALID_FRIEND_REQUEST);
-//        }
-//
-//        FriendRequest request = friendRequestRepository.findByRequesterIdAndReceiverId(requesterId, receiverId)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_NOT_FOUND));
-//
-//        if (!request.getStatus().equals(FriendRequestStatus.PENDING)) {
-//            throw new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_PENDING);
-//        }
-//
-//        // 요청 상태 변경
-//        request.accept();
-//
-//        // 친구 관계 저장 (양방향)
-//        Member requester = request.getRequester();
-//        Member receiver = request.getReceiver();
-//        friendRepository.saveFriendship(requester, receiver);
-//        friendRepository.saveFriendship(receiver, requester); // 양방향 저장
-//    }
-
     public void deleteFriend(Long currentMemberId, Long friendId) {
         Member current = memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Member target = memberRepository.findById(friendId)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        // 존재 여부 확인
         boolean exists = friendRepository.existsFriendshipByRequesterAndReceiver(current, target);
         if (!exists) {
             throw new FriendHandler(ErrorStatus.NOT_FRIEND);
         }
 
-        // soft delete
         friendRepository.softDeleteFriendship(current, target);
     }
 
@@ -177,42 +151,6 @@ public class FriendService {
         );
     }
 
-//    @Transactional
-//    public void refuseFriendRequest(FriendRequestRefuseRequestDTO requestDto) {
-//        Long receiverId = SecurityUtil.getCurrentMemberId();
-//        Member receiver = memberRepository.findById(receiverId)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//
-//        FriendRequest friendRequest = friendRequestRepository
-//                .findByRequesterIdAndReceiverIdAndStatus(requestDto.getRequesterId(), receiverId, FriendRequestStatus.PENDING)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_FOUND));
-//
-//        if (!friendRequest.getStatus().equals(FriendRequestStatus.PENDING)) {
-//            throw new FriendHandler(ErrorStatus.INVALID_FRIEND_REQUEST_STATUS);
-//        }
-//
-//        friendRequest.reject(); // 상태 변경
-//        friendRequestRepository.save(friendRequest);
-//    }
-//
-//    @Transactional
-//    public void cancelFriendRequest(FriendRequestCancelRequestDTO requestDto) {
-//        Long requesterId = SecurityUtil.getCurrentMemberId();
-//        Member requester = memberRepository.findById(requesterId)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//
-//        FriendRequest friendRequest = friendRequestRepository
-//                .findByRequesterIdAndReceiverIdAndStatus(requesterId, requestDto.getReceiverId(), FriendRequestStatus.PENDING)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_FOUND));
-//
-//        if (!friendRequest.getStatus().equals(FriendRequestStatus.PENDING)) {
-//            throw new FriendHandler(ErrorStatus.INVALID_FRIEND_REQUEST_STATUS);
-//        }
-//
-//        friendRequest.cancel(); // 상태 변경
-//        friendRequestRepository.save(friendRequest);
-//    }
-
     @Transactional
     public void acceptFriendRequest(Long receiverId, FriendRequestAcceptRequestDTO requestDto) {
         Long requesterId = requestDto.getRequesterId();
@@ -224,13 +162,12 @@ public class FriendService {
             throw new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_PENDING);
         }
 
-        // 친구 관계 저장
+        // 친구 관계 양방향 저장
         Member requester = request.getRequester();
         Member receiver = request.getReceiver();
         friendRepository.saveFriendship(requester, receiver);
         friendRepository.saveFriendship(receiver, requester);
 
-        // 요청 데이터 삭제 (ACCEPTED 상태로 굳이 남길 필요 없음)
         friendRequestRepository.delete(request);
     }
 
@@ -240,7 +177,6 @@ public class FriendService {
                 .findByRequesterIdAndReceiverIdAndStatus(requestDto.getRequesterId(), SecurityUtil.getCurrentMemberId(), FriendRequestStatus.PENDING)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_FOUND));
 
-        // 거절 후 삭제
         friendRequestRepository.delete(request);
     }
 
@@ -250,7 +186,6 @@ public class FriendService {
                 .findByRequesterIdAndReceiverIdAndStatus(SecurityUtil.getCurrentMemberId(), requestDto.getReceiverId(), FriendRequestStatus.PENDING)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_FOUND));
 
-        // 취소 후 삭제
         friendRequestRepository.delete(request);
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -1,6 +1,6 @@
 package org.lxdproject.lxd.member.service;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
@@ -21,6 +21,7 @@ import org.lxdproject.lxd.notification.service.NotificationService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -34,6 +35,7 @@ public class FriendService {
 
     private final NotificationService notificationService;
 
+    @Transactional(readOnly = true)
     public FriendListResponseDTO getFriendList(Long memberId, Pageable pageable) {
         Member member = findMemberById(memberId);
 
@@ -107,6 +109,7 @@ public class FriendService {
         notificationService.saveAndPublishNotification(dto);
     }
 
+    @Transactional
     public void acceptFriendRequest(Long receiverId, FriendRequestAcceptRequestDTO requestDto) {
         Long requesterId = requestDto.getRequesterId();
         FriendRequest request = friendRequestRepository
@@ -149,6 +152,7 @@ public class FriendService {
         friendRepository.softDeleteFriendship(current, target);
     }
 
+    @Transactional(readOnly = true)
     public FriendRequestListResponseDTO getPendingFriendRequests(Long memberId, Pageable receivedPage, Pageable sentPage) {
         Member currentMember = findMemberById(memberId);
 

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -66,7 +66,7 @@ public class FriendService {
             throw new FriendHandler(ErrorStatus.FRIEND_REQUEST_ALREADY_SENT);
         }
 
-        boolean alreadyFriends = friendRepository.existsByRequesterAndReceiverOrReceiverAndRequester(requester, receiver);
+        boolean alreadyFriends = friendRepository.existsFriendshipByRequesterAndReceiver(requester, receiver);
         if (alreadyFriends) {
             throw new FriendHandler(ErrorStatus.ALREADY_FRIENDS);
         }
@@ -111,7 +111,7 @@ public class FriendService {
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 존재 여부 확인
-        boolean exists = friendRepository.existsByRequesterAndReceiverOrReceiverAndRequester(current, target);
+        boolean exists = friendRepository.existsFriendshipByRequesterAndReceiver(current, target);
         if (!exists) {
             throw new FriendHandler(ErrorStatus.NOT_FRIEND);
         }

--- a/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/FriendService.java
@@ -97,28 +97,6 @@ public class FriendService {
     }
 
     public void acceptFriendRequest(Long receiverId, FriendRequestAcceptRequestDTO requestDto) {
-//        Long requesterId = requestDto.getRequesterId();
-//
-//        if (receiverId.equals(requesterId)) {
-//            throw new FriendHandler(ErrorStatus.INVALID_FRIEND_REQUEST);
-//        }
-//
-//        FriendRequest request = friendRequestRepository.findByRequesterIdAndReceiverId(requesterId, receiverId)
-//                .orElseThrow(() -> new FriendHandler(ErrorStatus.FRIEND_NOT_FOUND));
-//
-//        if (!request.getStatus().equals(FriendRequestStatus.PENDING)) {
-//            throw new FriendHandler(ErrorStatus.FRIEND_REQUEST_NOT_PENDING);
-//        }
-//
-//        // 요청 상태 변경
-//        request.accept();
-//
-//        // 친구 관계 저장 (양방향)
-//        Member requester = request.getRequester();
-//        Member receiver = request.getReceiver();
-//        friendRepository.saveFriendship(requester, receiver);
-//        friendRepository.saveFriendship(receiver, requester); // 양방향 저장
-
         Long requesterId = requestDto.getRequesterId();
         FriendRequest request = friendRequestRepository
                 .findByRequesterIdAndReceiverId(requesterId, receiverId)


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #167 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- `FriendRequest` 테이블에 `status` 가 `PENDING` 인 레코드만 저장하고 나머지 `ACCEPTED` 는 `FriendShip` 테이블에 저장 후 레코드 삭제, `REJECTED` 와 `CANCELED` 는 상태 바뀌자마자 삭제함. 
- → 이 때, `REJECTED` 나 `CANCELED` 후에도 재요청이 가능함!!
- `FriendShip` 로직에서는 cud에서는 양방향으로 저장하고 삭제, 수정을 진행하고 있었는데 r에서도 양방향으로 조회하고 있는 이슈가 있었음. 
- → r에서는 단방향으로 조회해서 중복 조회를 방지하도록 수정함. 

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- `FriendService`, `FriendRepositoryImpl`, ...

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 친구 요청 수락, 거절, 취소 시 처리 방식이 단순화되고 일관성 있게 개선되었습니다.
  * 친구 관계 확인 및 삭제, 생성 로직이 일방향/양방향 처리로 명확해졌습니다.

* **리팩터링**
  * 친구 목록 및 친구 요청 목록 조회에 페이지네이션이 도입되어 대용량 데이터 처리와 사용자 경험이 향상되었습니다.
  * 친구 요청 및 친구 목록 API에 페이지 및 크기 파라미터가 추가되어 조회 제어가 가능해졌습니다.
  * 친구 목록과 요청 응답 DTO가 페이지네이션을 지원하도록 변경되었습니다.
  * 불필요한 멤버 조회 및 상태 변경 로직이 정리되어 코드가 간결해졌습니다.
  * 친구 수 집계 방식이 최적화되어 효율적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->