### PR TITLE
[FEATURE] 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_USERNAME(HttpStatus.BAD_REQUEST, "MEMBER4001", "올바르지 않는 아이디 형식입니다."),
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4315", "올바르지 않은 닉네임 형식입니다."),
     INVALID_PROFILE_DATA(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임을 {\"nickname\":\"수정할 닉네임\"} 형식으로 요청해주세요."),
+    NEW_PASSWORDS_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "MEMBER4316", "새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다"),
+
+
 
     // 친구 관련 에러
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, "FRIEND4314", "이미 친구 요청을 보냈습니다."),

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -30,7 +30,7 @@ public interface AuthApi {
     })
     ApiResponse<AuthResponseDTO.LoginResponseDTO> login(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO loginRequestDTO);
 
-    @PostMapping("/emails/verification-requests")
+    @PostMapping("/verification-requests")
     @Operation(summary = "이메일 인증 링크 발송 API", description = "해당 이메일로 이메일 인증 링크를 발송합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 링크 전송 성공"),

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -30,7 +30,7 @@ public interface AuthApi {
     })
     ApiResponse<AuthResponseDTO.LoginResponseDTO> login(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO loginRequestDTO);
 
-    @PostMapping("/verification-requests")
+    @PostMapping("/emails/verification-requests")
     @Operation(summary = "이메일 인증 링크 발송 API", description = "해당 이메일로 이메일 인증 링크를 발송합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 링크 전송 성공"),

--- a/src/main/java/org/lxdproject/lxd/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/AuthRequestDTO.java
@@ -3,10 +3,12 @@ package org.lxdproject.lxd.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.lxdproject.lxd.auth.enums.VerificationType;
 
 public class AuthRequestDTO {
     @Getter
@@ -27,6 +29,11 @@ public class AuthRequestDTO {
     @Getter
     @Setter
     public static class sendVerificationRequestDTO{
+
+        @NotNull(message = "인증 타입은 필수입니다.")
+        @Schema(description = "인증 종류", example = "EMAIL")
+        private VerificationType verificationType;
+
         @NotBlank(message = "이메일은 필수입니다.")
         @Schema(description = "이메일", example = "apple123@gmail.com")
         private String email;

--- a/src/main/java/org/lxdproject/lxd/auth/enums/VerificationType.java
+++ b/src/main/java/org/lxdproject/lxd/auth/enums/VerificationType.java
@@ -1,0 +1,6 @@
+package org.lxdproject.lxd.auth.enums;
+
+public enum VerificationType {
+    EMAIL,
+    PASSWORD
+}

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/auth/login",
             "/auth/google/login",
-            "/auth/verification-requests",
+            "/auth/emails/verification-requests",
             "/auth/emails/verifications",
             "/auth/email",
             "/auth/email/**", // 쿼리 파라미터가 있는 경우 /** uri 추가로 붙여주기

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/auth/login",
             "/auth/google/login",
-            "/auth/emails/verification-requests",
+            "/auth/verification-requests",
             "/auth/emails/verifications",
             "/auth/email",
             "/auth/email/**", // 쿼리 파라미터가 있는 경우 /** uri 추가로 붙여주기

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
             "/members/join",
             "/members/check-username",
             "/members/check-username/**", // 쿼리 파라미터가 있는 경우 /** uri 추가로 붙여주기
-            "/members/password-verify",
+            "/members/password",
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/auth/login",

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -61,6 +61,6 @@ public interface MemberApi {
     ApiResponse<LanguageChangeResponseDTO> setLanguageSetting(@Valid @RequestBody LanguageSettingRequestDTO languageSetting);
 
     @Operation(summary = "비밀번호 변경 API", description = "이메일 인증이 완료된 계정의 비밀번호를 수정합니다.")
-    @PatchMapping("/system-language")
+    @PatchMapping("/password")
     ApiResponse<String> setPasswordSetting(@Valid @RequestBody MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO);
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -59,4 +59,8 @@ public interface MemberApi {
     @Operation(summary = "시스템 언어 변경 API", description = "로그인한 회원의 시스템 언어를 수정합니다.")
     @PatchMapping("/system-language")
     ApiResponse<LanguageChangeResponseDTO> setLanguageSetting(@Valid @RequestBody LanguageSettingRequestDTO languageSetting);
+
+    @Operation(summary = "비밀번호 변경 API", description = "이메일 인증이 완료된 계정의 비밀번호를 수정합니다.")
+    @PatchMapping("/system-language")
+    ApiResponse<String> setPasswordSetting(@Valid @RequestBody MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO);
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController implements MemberApi {
     }
 
     @Override
-    public ApiResponse<String> setPasswordSetting(MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO) {
+    public ApiResponse<String> setPasswordSetting(@Valid @RequestBody MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO) {
 
         memberService.setPasswordSetting(setPasswordSettingRequestDTO);
         return ApiResponse.onSuccess("비밀번호가 수정됐습니다.");

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -69,4 +69,11 @@ public class MemberController implements MemberApi {
         LanguageChangeResponseDTO response = memberService.setSystemLanguage(memberId, request);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
+
+    @Override
+    public ApiResponse<String> setPasswordSetting(MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        memberService.setPasswordSetting(memberId);
+        return ApiResponse.onSuccess("비밀번호가 수정됐습니다.");
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -72,8 +72,8 @@ public class MemberController implements MemberApi {
 
     @Override
     public ApiResponse<String> setPasswordSetting(MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
-        memberService.setPasswordSetting(memberId);
+
+        memberService.setPasswordSetting(setPasswordSettingRequestDTO);
         return ApiResponse.onSuccess("비밀번호가 수정됐습니다.");
     }
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -70,4 +70,19 @@ public class MemberRequestDTO {
 
     }
 
+    @Getter
+    @Schema(description = "비밀번호 변경을 위한 RequestDTO")
+    public static class SetPasswordSettingRequestDTO {
+
+       @NotBlank(message = "새 비밀번호 입력은 필수입니다.")
+       @Schema(description = "새로운 비밀번호", example = "Ab123456")
+       private String newPassword;
+
+       @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+       @Schema(description = "비밀번호 재입력", example = "Ab123456")
+       private String confirmNewPassword;
+
+    }
+
+
 }

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.lxdproject.lxd.diary.entity.enums.Language;
@@ -43,6 +40,7 @@ public class MemberRequestDTO {
 
         @NotBlank(message = "아이디는 필수입니다.")
         @Size(max = 20, message = "아이디는 최대 20자까지 가능합니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "아이디는 영문, 숫자, 언더바(_), 하이픈(-)만 가능합니다.")
         @Schema(description = "아이디", example = "snowman")
         String username;
 

--- a/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/member/dto/MemberRequestDTO.java
@@ -74,13 +74,17 @@ public class MemberRequestDTO {
     @Schema(description = "비밀번호 변경을 위한 RequestDTO")
     public static class SetPasswordSettingRequestDTO {
 
-       @NotBlank(message = "새 비밀번호 입력은 필수입니다.")
-       @Schema(description = "새로운 비밀번호", example = "Ab123456")
-       private String newPassword;
+        @NotBlank(message = "이메일 입력은 필수입니다.")
+        @Schema(description = "비밀번호를 변경할 이메일", example = "elucidator123@naver.com")
+        private String email;
 
-       @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
-       @Schema(description = "비밀번호 재입력", example = "Ab123456")
-       private String confirmNewPassword;
+        @NotBlank(message = "새 비밀번호 입력은 필수입니다.")
+        @Schema(description = "새로운 비밀번호", example = "Ab123456")
+        private String newPassword;
+
+        @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+        @Schema(description = "비밀번호 재입력", example = "Ab123456")
+        private String confirmNewPassword;
 
     }
 

--- a/src/main/java/org/lxdproject/lxd/member/entity/Member.java
+++ b/src/main/java/org/lxdproject/lxd/member/entity/Member.java
@@ -100,5 +100,5 @@ public class Member extends BaseEntity {
     public void updateSystemLanguage(Language systemLanguage) {
         this.systemLanguage = systemLanguage;
     }
-
+    public void updatePassword(String password) {this.password = password;}
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -156,4 +156,19 @@ public class MemberService {
                 .systemLanguage(member.getSystemLanguage())
                 .build();
     }
+
+    @Transactional
+    public void setPasswordSetting(MemberRequestDTO.SetPasswordSettingRequestDTO setPasswordSettingRequestDTO) {
+
+        // 새 비밀번호와 새 비밀번호 확인이 일치하지 않을 경우
+        if(!setPasswordSettingRequestDTO.getNewPassword().equals(setPasswordSettingRequestDTO.getConfirmNewPassword())){
+            throw new MemberHandler(ErrorStatus.NEW_PASSWORDS_DO_NOT_MATCH);
+        }
+
+        Member member = memberRepository.findByEmail(setPasswordSettingRequestDTO.getEmail())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updatePassword(passwordEncoder.encode(setPasswordSettingRequestDTO.getNewPassword()));
+
+    }
 }

--- a/src/main/resources/templates/password.html
+++ b/src/main/resources/templates/password.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>LXD 비밀번호 재설정</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f4f4f4;">
+<div style="font-family:'Apple SD Gothic Neo', sans-serif; max-width:480px; margin:40px auto; border-radius:12px; background-color:#ffffff; box-shadow:0 0 20px rgba(0,0,0,0.05); padding:48px 24px; text-align:center;">
+
+    <!-- 로고 -->
+    <img src="https://cdn.jsdelivr.net/gh/eclipse021/git_test@main/logo.png" alt="LXD 로고" style="width:90px; height:76px; margin:0 auto 24px; display:block;">
+
+    <!-- 타이틀 -->
+    <div style="font-size:20px; font-weight:bold; margin-bottom:8px;">🔑 비밀번호 재설정 요청</div>
+
+    <!-- 서브타이틀 -->
+    <div style="font-size:16px; margin-bottom:24px;">안녕하세요!</div>
+
+    <!-- 내용 -->
+    <div style="font-size:14px; line-height:1.6; color:#333333; margin-bottom:36px;">
+        아래 버튼을 눌러 비밀번호 재설정을 진행해 주세요.<br>
+        이 링크는 <strong>5분간 유효</strong>합니다.<br>
+        만약 비밀번호 재설정을 요청하지 않으셨다면<br>
+        본 이메일을 무시하셔도 됩니다.
+    </div>
+
+    <!-- 버튼 -->
+    <a href="{{verificationLink}}" style="
+            display:inline-block;
+            padding:14px 28px;
+            background-color:#3D63EA;
+            color:#ffffff;
+            border-radius:8px;
+            text-decoration:none;
+            font-weight:bold;
+            font-size:14px;
+            margin-bottom:36px;
+        ">비밀번호 재설정하기</a>
+
+    <!-- 푸터 -->
+    <div style="margin-top:40px; font-size:12px; color:#999999; line-height:1.4;">
+        본 메일은 <strong>발신 전용</strong>입니다.<br>
+        문의사항이 있으시면 고객센터로 연락해주세요.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #185 

## ✏️ Summary
비밀번호 변경(재설정) 및 관련 인증 프로세스 구현
- 비밀번호 변경 API 구현
- 이메일 인증 및 비밀번호 변경 화면으로 리다이렉트 API 수정

## 📝 Changes
- 비밀번호 변경
  - 인증된 이메일(email), 새 비밀번호(newPassword), 새 비밀번호 확인(ConfirmNewPassword) 3개의 필드로 입력받도록 구현
  - 두 값이 일치하지 않으면(새 비밀번호 != 새 비밀번호 확인) 예외반환 하며 일치할 시 해당 비밀번호로 비밀번호 변경
 
- 이메일 인증 및 비밀번호 변경 화면으로 리다이렉트
  - /auth/verification-requests API에 verificationType(EMAIL / PASSWORD)으로 이메일 전송 분기 처리하도록 수정
  - Redis에 토큰 저장 및 조회를 할 때 value에 List 구조로 ("email" 또는 password", 이메일) 을 저장하도록 개선 
  - value(0)의 값에 따라 리다이렉트 주소 분기 처리
  - 이메일 토큰 유효성 검사 및 예외처리


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="1221" height="739" alt="image" src="https://github.com/user-attachments/assets/98252a87-aa33-4c5b-8727-bf55c988f452" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 인증 및 비밀번호 재설정 요청 시 인증 유형을 구분할 수 있도록 개선되었습니다.
  * 비밀번호 재설정(변경) API가 추가되어, 이메일 인증을 완료한 사용자가 비밀번호를 변경할 수 있습니다.
  * 비밀번호 재설정 안내를 위한 새로운 이메일 템플릿이 추가되었습니다.

* **버그 수정**
  * 새 비밀번호와 비밀번호 확인이 일치하지 않을 때 명확한 오류 메시지가 제공됩니다.

* **기타**
  * 일부 인증 및 비밀번호 관련 엔드포인트 경로가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->