### PR TITLE
[FIX] diary/liked 엔드포인트의 isLiked 필드 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -228,6 +228,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     @Override
     public DiarySliceResponseDTO findLikedDiariesOfFriends(Long userId, Pageable pageable) {
+        Set<Long> likedSet = getLikedDiaryIdSet(userId);
         QDiaryLike diaryLike = QDiaryLike.diaryLike;
         QDiary diary = QDiary.diary;
         QMember member = QMember.member;
@@ -286,6 +287,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
                         .writerUsername(d.getMember().getUsername())
                         .writerNickname(d.getMember().getNickname())
                         .writerProfileImg(d.getMember().getProfileImg())
+                        .liked(likedSet.contains(d.getId()))
                         .build()
                 )
                 .toList();

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -31,10 +31,6 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-//    QDiary diary = QDiary.diary;
-//    QDiaryLike diaryLike = QDiaryLike.diaryLike;
-//    QFriendship friendship = QFriendship.friendship;
-
     private static final QDiary DIARY = QDiary.diary;
     private static final QDiaryLike DIARY_LIKE = QDiaryLike.diaryLike;
     private static final QFriendship FRIENDSHIP = QFriendship.friendship;
@@ -178,11 +174,8 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     @Override
     public DiarySliceResponseDTO findDiariesOfFriends(Long userId, Pageable pageable) {
+
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
-
-//        QDiary diary = QDiary.diary;
-//        QMember member = QMember.member;
-
         Set<Long> friendIds = getFriendIds(userId);
 
         List<Diary> diaries = queryFactory
@@ -232,12 +225,8 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     @Override
     public DiarySliceResponseDTO findLikedDiariesOfFriends(Long userId, Pageable pageable) {
-        Set<Long> likedSet = getLikedDiaryIdSet(userId);
-//        QDiaryLike diaryLike = QDiaryLike.diaryLike;
-//        QDiary diary = QDiary.diary;
-//        QMember member = QMember.member;
-//        QFriendship friendship = QFriendship.friendship;
 
+        Set<Long> likedSet = getLikedDiaryIdSet(userId);
         List<Long> likedDiaryIds = queryFactory
                 .select(DIARY_LIKE.diary.id)
                 .from(DIARY_LIKE)

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -6,14 +6,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
-import org.lxdproject.lxd.diary.dto.*;
-import org.lxdproject.lxd.diary.entity.Diary;
-import org.lxdproject.lxd.diary.entity.QDiary;
-import org.lxdproject.lxd.diary.entity.enums.Language;
-import org.lxdproject.lxd.diary.entity.enums.Visibility;
-import org.lxdproject.lxd.diarylike.entity.QDiaryLike;
-import org.lxdproject.lxd.friend.entity.QFriendship;
-import org.lxdproject.lxd.member.entity.QMember;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
@@ -22,17 +14,31 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.lxdproject.lxd.diary.dto.*;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.entity.enums.Language;
+import org.lxdproject.lxd.diary.entity.enums.Visibility;
+
+import org.lxdproject.lxd.diary.entity.QDiary;
+import org.lxdproject.lxd.diarylike.entity.QDiaryLike;
+import org.lxdproject.lxd.friend.entity.QFriendship;
+import org.lxdproject.lxd.member.entity.QMember;
+
 import static org.lxdproject.lxd.diary.util.DiaryUtil.generateContentPreview;
-import static org.lxdproject.lxd.member.entity.QMember.member;
 
 @RequiredArgsConstructor
 public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    QDiary diary = QDiary.diary;
-    QDiaryLike diaryLike = QDiaryLike.diaryLike;
-    QFriendship friendship = QFriendship.friendship;
+//    QDiary diary = QDiary.diary;
+//    QDiaryLike diaryLike = QDiaryLike.diaryLike;
+//    QFriendship friendship = QFriendship.friendship;
+
+    private static final QDiary DIARY = QDiary.diary;
+    private static final QDiaryLike DIARY_LIKE = QDiaryLike.diaryLike;
+    private static final QFriendship FRIENDSHIP = QFriendship.friendship;
+    private static final QMember MEMBER = QMember.member;
 
     @Override
     public MyDiarySliceResponseDTO findMyDiaries(Long userId, Boolean likedOnly, Pageable pageable) {
@@ -40,15 +46,15 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
 
         List<Diary> diaries = queryFactory
-                .selectFrom(diary)
-                .leftJoin(diary.likes, diaryLike)
+                .selectFrom(DIARY)
+                .leftJoin(DIARY.likes, DIARY_LIKE)
                 .where(
-                        diary.member.id.eq(userId),
-                        diary.deletedAt.isNull(),
-                        likedOnly != null && likedOnly ? diaryLike.member.id.eq(userId) : null
+                        DIARY.member.id.eq(userId),
+                        DIARY.deletedAt.isNull(),
+                        likedOnly != null && likedOnly ? DIARY_LIKE.member.id.eq(userId) : null
                 )
                 .distinct()
-                .orderBy(diary.createdAt.desc())
+                .orderBy(DIARY.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -85,29 +91,27 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
     public MyDiarySliceResponseDTO getDiariesByMemberId(Long userId, Long memberId, Pageable pageable) {
 
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
-
         Set<Long> friendIds = getFriendIds(userId);
-
         BooleanExpression visibilityCondition;
 
         if (userId.equals(memberId)) { // 본인
-            visibilityCondition = diary.visibility.in(Visibility.PUBLIC, Visibility.FRIENDS, Visibility.PRIVATE);
+            visibilityCondition = DIARY.visibility.in(Visibility.PUBLIC, Visibility.FRIENDS, Visibility.PRIVATE);
         } else if (friendIds.contains(memberId)) { // 친구관계
-            visibilityCondition = diary.visibility.in(Visibility.PUBLIC, Visibility.FRIENDS);
+            visibilityCondition = DIARY.visibility.in(Visibility.PUBLIC, Visibility.FRIENDS);
         } else { // 타인
-            visibilityCondition = diary.visibility.eq(Visibility.PUBLIC);
+            visibilityCondition = DIARY.visibility.eq(Visibility.PUBLIC);
         }
 
         List<Diary> diaries = queryFactory
-                .selectFrom(diary)
-                .leftJoin(diary.likes, diaryLike).fetchJoin()
+                .selectFrom(DIARY)
+                .leftJoin(DIARY.likes, DIARY_LIKE).fetchJoin()
                 .where(
-                        diary.member.id.eq(memberId),
-                        diary.deletedAt.isNull(),
+                        DIARY.member.id.eq(memberId),
+                        DIARY.deletedAt.isNull(),
                         visibilityCondition
                 )
                 .distinct()
-                .orderBy(diary.createdAt.desc())
+                .orderBy(DIARY.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -147,15 +151,15 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = YearMonth.of(year, month).atEndOfMonth();
 
-        var dateExpression = Expressions.stringTemplate("DATE({0})", diary.createdAt);
+        var dateExpression = Expressions.stringTemplate("DATE({0})", DIARY.createdAt);
 
         return queryFactory
-                .select(dateExpression, diary.count())
-                .from(diary)
+                .select(dateExpression, DIARY.count())
+                .from(DIARY)
                 .where(
-                        diary.member.id.eq(userId),
-                        diary.deletedAt.isNull(),
-                        diary.createdAt.between(start.atStartOfDay(), end.atTime(23, 59, 59))
+                        DIARY.member.id.eq(userId),
+                        DIARY.deletedAt.isNull(),
+                        DIARY.createdAt.between(start.atStartOfDay(), end.atTime(23, 59, 59))
                 )
                 .groupBy(dateExpression)
                 .orderBy(dateExpression.asc())
@@ -167,7 +171,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
                             ? ((java.sql.Date) dateObj).toLocalDate().toString()
                             : dateObj.toString();
 
-                    return new DiaryStatsResponseDTO(date, tuple.get(diary.count()));
+                    return new DiaryStatsResponseDTO(date, tuple.get(DIARY.count()));
                 })
                 .toList();
     }
@@ -176,20 +180,20 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
     public DiarySliceResponseDTO findDiariesOfFriends(Long userId, Pageable pageable) {
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
 
-        QDiary diary = QDiary.diary;
-        QMember member = QMember.member;
+//        QDiary diary = QDiary.diary;
+//        QMember member = QMember.member;
 
         Set<Long> friendIds = getFriendIds(userId);
 
         List<Diary> diaries = queryFactory
-                .selectFrom(diary)
-                .leftJoin(diary.member, member).fetchJoin()
+                .selectFrom(DIARY)
+                .leftJoin(DIARY.member, MEMBER).fetchJoin()
                 .where(
-                        diary.member.id.in(friendIds),
-                        diary.visibility.ne(Visibility.PRIVATE),
-                        diary.deletedAt.isNull()
+                        DIARY.member.id.in(friendIds),
+                        DIARY.visibility.ne(Visibility.PRIVATE),
+                        DIARY.deletedAt.isNull()
                 )
-                .orderBy(diary.createdAt.desc())
+                .orderBy(DIARY.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -229,15 +233,15 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
     @Override
     public DiarySliceResponseDTO findLikedDiariesOfFriends(Long userId, Pageable pageable) {
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
-        QDiaryLike diaryLike = QDiaryLike.diaryLike;
-        QDiary diary = QDiary.diary;
-        QMember member = QMember.member;
-        QFriendship friendship = QFriendship.friendship;
+//        QDiaryLike diaryLike = QDiaryLike.diaryLike;
+//        QDiary diary = QDiary.diary;
+//        QMember member = QMember.member;
+//        QFriendship friendship = QFriendship.friendship;
 
         List<Long> likedDiaryIds = queryFactory
-                .select(diaryLike.diary.id)
-                .from(diaryLike)
-                .where(diaryLike.member.id.eq(userId))
+                .select(DIARY_LIKE.diary.id)
+                .from(DIARY_LIKE)
+                .where(DIARY_LIKE.member.id.eq(userId))
                 .fetch();
 
         if (likedDiaryIds.isEmpty()) {
@@ -252,19 +256,19 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
         Set<Long> friendIds = getFriendIds(userId);
 
         List<Diary> diaries = queryFactory
-                .selectFrom(diary)
-                .join(diary.member, member).fetchJoin()
+                .selectFrom(DIARY)
+                .join(DIARY.member, MEMBER).fetchJoin()
                 .where(
-                        diary.id.in(likedDiaryIds),
-                        diary.member.id.ne(userId),
-                        diary.deletedAt.isNull(),
-                        diary.visibility.eq(Visibility.PUBLIC)
+                        DIARY.id.in(likedDiaryIds),
+                        DIARY.member.id.ne(userId),
+                        DIARY.deletedAt.isNull(),
+                        DIARY.visibility.eq(Visibility.PUBLIC)
                                 .or(
-                                        diary.visibility.eq(Visibility.FRIENDS)
-                                                .and(diary.member.id.in(friendIds))
+                                        DIARY.visibility.eq(Visibility.FRIENDS)
+                                                .and(DIARY.member.id.in(friendIds))
                                 )
                 )
-                .orderBy(diary.createdAt.desc())
+                .orderBy(DIARY.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -306,19 +310,19 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
         Set<Long> friendIds = getFriendIds(userId);
 
         BooleanBuilder condition = new BooleanBuilder();
-        condition.or(diary.visibility.eq(Visibility.PUBLIC));
-        condition.or(diary.visibility.eq(Visibility.FRIENDS).and(diary.member.id.in(friendIds)));
-        condition.or(diary.visibility.eq(Visibility.PRIVATE).and(diary.member.id.eq(userId)));
+        condition.or(DIARY.visibility.eq(Visibility.PUBLIC));
+        condition.or(DIARY.visibility.eq(Visibility.FRIENDS).and(DIARY.member.id.in(friendIds)));
+        condition.or(DIARY.visibility.eq(Visibility.PRIVATE).and(DIARY.member.id.eq(userId)));
 
         if (language != null) {
-            condition.and(diary.language.eq(language));
+            condition.and(DIARY.language.eq(language));
         }
 
         List<Diary> diaries = queryFactory
-                .selectFrom(diary)
-                .join(diary.member, member).fetchJoin()
-                .where(condition, diary.deletedAt.isNull())
-                .orderBy(diary.createdAt.desc())
+                .selectFrom(DIARY)
+                .join(DIARY.member, MEMBER).fetchJoin()
+                .where(condition, DIARY.deletedAt.isNull())
+                .orderBy(DIARY.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
@@ -357,15 +361,15 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     private Set<Long> getFriendIds(Long userId) {
         List<Long> sentFriendIds = queryFactory
-                .select(friendship.receiver.id)
-                .from(friendship)
-                .where(friendship.requester.id.eq(userId), friendship.deletedAt.isNull())
+                .select(FRIENDSHIP.receiver.id)
+                .from(FRIENDSHIP)
+                .where(FRIENDSHIP.requester.id.eq(userId), FRIENDSHIP.deletedAt.isNull())
                 .fetch();
 
         List<Long> receivedFriendIds = queryFactory
-                .select(friendship.requester.id)
-                .from(friendship)
-                .where(friendship.receiver.id.eq(userId), friendship.deletedAt.isNull())
+                .select(FRIENDSHIP.requester.id)
+                .from(FRIENDSHIP)
+                .where(FRIENDSHIP.receiver.id.eq(userId), FRIENDSHIP.deletedAt.isNull())
                 .fetch();
 
         Set<Long> friendIds = new HashSet<>();
@@ -377,9 +381,9 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
 
     private Set<Long> getLikedDiaryIdSet(Long userId) {
         List<Long> likedDiaryIds = queryFactory
-                .select(diaryLike.diary.id)
-                .from(diaryLike)
-                .where(diaryLike.member.id.eq(userId))
+                .select(DIARY_LIKE.diary.id)
+                .from(DIARY_LIKE)
+                .where(DIARY_LIKE.member.id.eq(userId))
                 .fetch();
         return new HashSet<>(likedDiaryIds);
     }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #190 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- isLiked 필드를 응답값에 추가하는 과정에서 `MyDiarySummaryResponseDTO`, `DiarySummaryResponseDTO` 에는 필드를 추가했지만 해당 DTO를 공유하는 엔드포인트 몇몇의 builder에서는 정보를 누락한 것을 확인함
- 그에 따라서 몇몇 엔드포인트에서는 정확한 isLiked 값이 아닌, 디폴트 값인 false 로 고정되어서 반환되고 있음
- 이를 수정하기 위해 builder 코드 수정함
- 또한, `QClass` 들이 중복으로 import 되고 있는 것을 확인하고 `private static final` 로 전역에서 사용하도록 수정함

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 쿼리 엔티티 참조 방식을 일관성 있게 개선하여 코드 가독성을 향상시켰습니다.

* **Bug Fixes**
  * 친구의 좋아요 일기 조회 시, 각 일기에 대한 좋아요 여부가 정확하게 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->