### PR TITLE
[FEATURE] 내 일기가 탐색탭에 노출되지 않도록 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -298,10 +298,17 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
         Set<Long> friendIds = getFriendIds(userId);
 
-        BooleanBuilder condition = new BooleanBuilder();
-        condition.or(DIARY.visibility.eq(Visibility.PUBLIC));
-        condition.or(DIARY.visibility.eq(Visibility.FRIENDS).and(DIARY.member.id.in(friendIds)));
-        condition.or(DIARY.visibility.eq(Visibility.PRIVATE).and(DIARY.member.id.eq(userId)));
+        // visibilityCondition : PUBLIC or FRIENDS and 친구관계
+        BooleanBuilder visibilityCondition = new BooleanBuilder()
+                .or(DIARY.visibility.eq(Visibility.PUBLIC))
+                .or(DIARY.visibility.eq(Visibility.FRIENDS)
+                        .and(DIARY.member.id.in(friendIds)));
+
+        // 내 일기 제외 + 삭제 안 됨 + visibilityCondition
+        BooleanBuilder condition = new BooleanBuilder()
+                .and(DIARY.member.id.ne(userId))
+                .and(DIARY.deletedAt.isNull())
+                .and(visibilityCondition);
 
         if (language != null) {
             condition.and(DIARY.language.eq(language));


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #199 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- 내 일기가 탐색탭에 노출되지 않아야 하는 요구사항이 미반영되어서 수정함

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

-  `findExploreDiaries` 메서드 수정해서 `userId`가 `DIARY.member.id.ne(userId)` 이면 조회되지 않도록 수정함

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 탐색 피드에서 사용자의 본인 일기가 더 이상 노출되지 않습니다.
  - 삭제된 일기가 피드에 표시되지 않습니다.
  - 공개 또는 친구 공개 범위만 노출되며, 친구 공개는 실제 친구의 일기만 포함됩니다.
  - 언어 필터는 지정된 경우에만 적용되며, 기존 정렬·페이지네이션 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->