### PR TITLE
[FEATURE] 일기 목록에서 writerId 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiarySummaryResponseDTO.java
@@ -14,6 +14,7 @@ public class DiarySummaryResponseDTO {
     private String writerUsername;
     private String writerNickname;
     private String writerProfileImg;
+    private Long writerId;
     private Long diaryId;
     private String createdAt;
     private String title;

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryCustom.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface DiaryRepositoryCustom {
     MyDiarySliceResponseDTO getDiariesByMemberId (Long userId, Long memberId, Pageable pageable);
     List<DiaryStatsResponseDTO> getDiaryStatsByMonth(Long userId, int year, int month);
     DiarySliceResponseDTO findDiariesOfFriends(Long userId, Pageable pageable);
-    DiarySliceResponseDTO findLikedDiariesOfFriends(Long userId, Pageable pageable);
+    DiarySliceResponseDTO findLikedDiaries(Long userId, Pageable pageable);
     DiarySliceResponseDTO findExploreDiaries(Long userId, Language language, Pageable pageable);
 }
 

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -335,6 +335,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
                         .writerUsername(d.getMember().getUsername())
                         .writerNickname(d.getMember().getNickname())
                         .writerProfileImg(d.getMember().getProfileImg())
+                        .writerId(d.getMember().getId())
                         .diaryId(d.getId())
                         .createdAt(DateFormatUtil.formatDate(d.getCreatedAt()))
                         .title(d.getTitle())

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -211,6 +211,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
                         .writerUsername(d.getMember().getUsername())
                         .writerNickname(d.getMember().getNickname())
                         .writerProfileImg(d.getMember().getProfileImg())
+                        .writerId(d.getMember().getId())
                         .liked(likedSet.contains(d.getId()))
                         .build())
                 .toList();

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -225,7 +225,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
     }
 
     @Override
-    public DiarySliceResponseDTO findLikedDiariesOfFriends(Long userId, Pageable pageable) {
+    public DiarySliceResponseDTO findLikedDiaries(Long userId, Pageable pageable) {
 
         Set<Long> likedSet = getLikedDiaryIdSet(userId);
         List<Long> likedDiaryIds = queryFactory

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -281,6 +281,7 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
                         .writerUsername(d.getMember().getUsername())
                         .writerNickname(d.getMember().getNickname())
                         .writerProfileImg(d.getMember().getProfileImg())
+                        .writerId(d.getMember().getId())
                         .liked(likedSet.contains(d.getId()))
                         .build()
                 )

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -179,7 +179,7 @@ public class DiaryService {
 
     public DiarySliceResponseDTO getLikedDiaries(Pageable pageable) {
         Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        return diaryRepository.findLikedDiariesOfFriends(currentMemberId, pageable);
+        return diaryRepository.findLikedDiaries(currentMemberId, pageable);
     }
 
     public DiarySliceResponseDTO getExploreDiaries(Pageable pageable, Language language) {


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #204 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- `writerId` 일기 응답값에 공통 추가하기

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- `DiarySummaryResponseDTO`, `DiaryRepositoryImpl`, ...

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 일기 요약에 작성자 식별 정보가 추가되어 작성자 관련 표시/이동이 더 정확해졌습니다.
  * ‘좋아요한 일기’ 목록이 이제 사용자가 직접 좋아요한 일기들을 보여줍니다.
* Bug Fixes
  * 탐색 피드 노출 기준을 조정해 내 비공개 일기는 제외하고, 다른 사용자의 공개/친구공개 일기만 표시됩니다.
  * 삭제된 일기는 더 이상 목록에 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->