### PR TITLE
[FEATURE] 일기 상세 조회 반환값에 memberId 추가하기

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -21,6 +21,7 @@ public class DiaryDetailResponseDTO {
     private String profileImg;
     private String writerNickName;
     private String writerUserName;
+    private Long writerId;
     private String createdAt;
     private int commentCount;
     private int likeCount;
@@ -42,6 +43,7 @@ public class DiaryDetailResponseDTO {
                 member.getProfileImg(),
                 member.getNickname(),
                 member.getUsername(),
+                member.getId(),
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),
@@ -65,6 +67,7 @@ public class DiaryDetailResponseDTO {
                 member.getProfileImg(),
                 member.getNickname(),
                 member.getUsername(),
+                member.getId(),
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->

closed #219 


## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->

- 일기 상세 조회 반환값에 memberId 추가하기


## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- `DiaryDetailResponseDTO` 수정
## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 일기 상세 조회 응답에 작성자 ID 필드가 추가되어 작성자 식별 정보가 함께 제공됩니다.
  * 해당 필드는 기존 작성자 이름과 함께 반환되며 응답 스키마와 빌더에도 반영되었습니다.
  * 추가된 값은 정수형 ID로 제공됩니다.
  * 기존 기능에는 변화가 없으며, 새 필드를 사용하지 않는 클라이언트에 대한 영향은 최소입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->