### PR TITLE
[REFACTOR] 일기 댓글 조회/삭제 API 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -9,8 +9,6 @@ import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentDeleteResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentRequestDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentResponseDTO;
-import org.lxdproject.lxd.diarycomment.dto.DiaryCommentResponseDTO;
-import org.lxdproject.lxd.validation.annotation.ValidPageSize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Correction Comment API", description = "교정 댓글 관련 API 입니다.")

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentApi.java
@@ -9,6 +9,7 @@ import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentDeleteResponseDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentRequestDTO;
 import org.lxdproject.lxd.correctioncomment.dto.CorrectionCommentResponseDTO;
+import org.lxdproject.lxd.diarycomment.dto.DiaryCommentResponseDTO;
 import org.lxdproject.lxd.validation.annotation.ValidPageSize;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.apiPayload.code.status.SuccessStatus;
 import org.lxdproject.lxd.common.dto.PageResponse;
-import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.correctioncomment.dto.*;
 import org.lxdproject.lxd.correctioncomment.service.CorrectionCommentService;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -4,6 +4,7 @@ import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,7 @@ public interface CorrectionCommentRepository extends JpaRepository<CorrectionCom
 
     @Query("SELECT cc.correction.diary.title FROM CorrectionComment cc WHERE cc.id = :id AND cc.correction IS NOT NULL AND cc.correction.diary IS NOT NULL")
     Optional<String> findDiaryTitleByCorrectionCommentId(@Param("id") Long id);
+
 
 }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/repository/CorrectionCommentRepository.java
@@ -4,7 +4,6 @@ import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -68,6 +68,7 @@ public class CorrectionCommentService {
 
         Page<CorrectionComment> commentPage = commentRepository.findByCorrection(correction, pageable);
 
+
         List<CorrectionCommentResponseDTO> content = commentPage.stream()
                 .map(comment -> CorrectionCommentResponseDTO.builder()
                         .commentId(comment.getId())

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diarycomment.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.diarycomment.dto.*;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +20,7 @@ public interface DiaryCommentApi {
 
     @Operation(summary = "일기 댓글 조회 API", description = "해당 일기의 댓글들을 생성일 기준으로 조회합니다.")
     @GetMapping
-    ApiResponse<DiaryCommentResponseDTO.CommentList> getComments(
+    ApiResponse<PageResponse<DiaryCommentResponseDTO.Comment>> getComments(
             @PathVariable Long diaryId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diarycomment.controller;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.apiPayload.code.status.SuccessStatus;
+import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.diarycomment.dto.*;
 import org.lxdproject.lxd.diarycomment.service.DiaryCommentService;
@@ -29,11 +30,10 @@ public class DiaryCommentController implements DiaryCommentApi {
     }
 
     @Override
-    public ApiResponse<DiaryCommentResponseDTO.CommentList> getComments(
-            Long diaryId, int page, int size
-    ) {
+    public ApiResponse<PageResponse<DiaryCommentResponseDTO.Comment>> getComments(Long diaryId, int page, int size) {
+        // ASC 정렬 유지(요구에 맞게 DESC로 바꿔도 됨; replies도 같은 방향)
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
-        DiaryCommentResponseDTO.CommentList response =
+        PageResponse<DiaryCommentResponseDTO.Comment> response =
                 diaryCommentService.getComments(diaryId, pageable);
         return ApiResponse.of(SuccessStatus._OK, response);
     }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/converter/DiaryCommentConverter.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/converter/DiaryCommentConverter.java
@@ -30,7 +30,7 @@ public class DiaryCommentConverter {
                 .likeCount(comment.getLikeCount())
                 .isLiked(likedCommentIds.contains(comment.getId()))
                 .createdAt(DateFormatUtil.formatDate(comment.getCreatedAt()))
-                .replyCount(comment.getReplyCount())
+                .replyCount(replies.size())
                 .replies(replies)
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -47,7 +47,8 @@ public class DiaryCommentResponseDTO {
     @NoArgsConstructor
     public static class CommentList {
         private List<Comment> content;
+        private long totalParentComments; // 부모 댓글 총 개수
         private int totalElements;
+        private int pageItemCount; // 이 페이지에 포함된 실제 댓글수(부모+대댓글)
     }
-
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -14,6 +14,7 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
     Page<DiaryComment> findByDiaryIdAndParentIsNull(Long diaryId, Pageable pageable);
     List<DiaryComment> findByParentIdIn(List<Long> parentIds);
 
+
     @Query("SELECT COUNT(c) FROM DiaryComment c WHERE c.diary.id = :diaryId")
     long countAllCommentsIncludingDeleted(@Param("diaryId") Long diaryId);
 


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #222 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기 댓글 관련 API를 수정했습니다.

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
일기 댓글
-일기 댓글 조회 totalElement 및 page DTO 수정
-일기 댓글(부모댓글)삭제 시 대댓글 작성 방지

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 일기 댓글 조회가 페이지네이션 응답으로 개선되어 총 댓글 수와 페이지 아이템 수 등을 제공하며, 부모-답글 트리 구조로 반환됩니다.
- 버그 수정
  - 삭제된 부모 댓글에는 더 이상 답글을 작성할 수 없습니다.
  - 댓글 삭제 시 작성자 본인만 삭제할 수 있도록 권한 검증을 강화했습니다.
  - replyCount가 실제 포함된 답글 수를 정확히 반영하도록 수정했습니다.
- 기타
  - 불필요한 임포트 정리 및 경미한 코드 포맷팅 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->