### PR TITLE
[REFACTOR] 일기 댓글 조회 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/controller/CorrectionCommentController.java
@@ -29,8 +29,7 @@ public class CorrectionCommentController implements CorrectionCommentApi {
 
     @Override
     public ApiResponse<PageResponse<CorrectionCommentResponseDTO>> getComments(Long correctionId, int page, int size) {
-        Pageable pageable = PageRequest.of(page-1, size, Sort.by(Sort.Direction.ASC, "createdAt"));
-        PageResponse<CorrectionCommentResponseDTO> response = correctionCommentService.getComments(correctionId, pageable);
+        PageResponse<CorrectionCommentResponseDTO> response = correctionCommentService.getComments(correctionId, page, size);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -21,7 +21,9 @@ import org.lxdproject.lxd.notification.entity.enums.NotificationType;
 import org.lxdproject.lxd.notification.entity.enums.TargetType;
 import org.lxdproject.lxd.notification.service.NotificationService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -82,9 +84,11 @@ public class CorrectionCommentService {
 
 
     @Transactional(readOnly = true)
-    public PageResponse<CorrectionCommentResponseDTO> getComments(Long correctionId, Pageable pageable) {
+    public PageResponse<CorrectionCommentResponseDTO> getComments(Long correctionId, int page, int size) {
         Correction correction = correctionRepository.findById(correctionId)
                 .orElseThrow(() -> new CorrectionHandler(ErrorStatus.CORRECTION_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.ASC, "createdAt"));
 
         Page<CorrectionComment> commentPage = commentRepository.findByCorrection(correction, pageable);
 

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentApi.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diarycomment.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
+import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.diarycomment.dto.*;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,9 +20,9 @@ public interface DiaryCommentApi {
 
     @Operation(summary = "일기 댓글 조회 API", description = "해당 일기의 댓글들을 생성일 기준으로 조회합니다.")
     @GetMapping
-    ApiResponse<DiaryCommentResponseDTO.CommentList> getComments(
+    ApiResponse<PageResponse<DiaryCommentResponseDTO.Comment>> getComments(
             @PathVariable Long diaryId,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     );
 

--- a/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/controller/DiaryCommentController.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diarycomment.controller;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.ApiResponse;
 import org.lxdproject.lxd.apiPayload.code.status.SuccessStatus;
+import org.lxdproject.lxd.common.dto.PageResponse;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.diarycomment.dto.*;
 import org.lxdproject.lxd.diarycomment.service.DiaryCommentService;
@@ -28,13 +29,11 @@ public class DiaryCommentController implements DiaryCommentApi {
     }
 
     @Override
-    public ApiResponse<DiaryCommentResponseDTO.CommentList> getComments(
+    public ApiResponse<PageResponse<DiaryCommentResponseDTO.Comment>> getComments(
             Long diaryId, int page, int size
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
-        DiaryCommentResponseDTO.CommentList response =
-                diaryCommentService.getComments(diaryId, pageable);
-        return ApiResponse.of(SuccessStatus._OK, response);
+        PageResponse<DiaryCommentResponseDTO.Comment> dto = diaryCommentService.getComments(diaryId, page - 1, size);
+        return ApiResponse.of(SuccessStatus._OK, dto);
     }
 
     @Override

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -41,13 +41,4 @@ public class DiaryCommentResponseDTO {
         private List<Comment> replies;  //대댓글
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class CommentList {
-        private List<Comment> content;
-        private int totalElements;
-    }
-
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -10,13 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long> {
-    Page<DiaryComment> findByDiaryIdAndParentIsNull(Long diaryId, Pageable pageable);
-    List<DiaryComment> findByParentIdIn(List<Long> parentIds);
-
-    @Query("SELECT COUNT(c) FROM DiaryComment c WHERE c.diary.id = :diaryId")
-    long countAllCommentsIncludingDeleted(@Param("diaryId") Long diaryId);
-
+public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long>, DiaryCommentRepositoryCustom {
     @Query("SELECT dc.diary.title FROM DiaryComment dc WHERE dc.id = :id AND dc.diary IS NOT NULL")
     Optional<String> findDiaryTitleByCommentId(@Param("id") Long id);
 

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryCustom.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.lxdproject.lxd.diarycomment.repository;
+
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+
+import java.util.List;
+
+public interface DiaryCommentRepositoryCustom {
+    List<DiaryComment> findParentComments(Long diaryId, int offset, int size);
+    List<DiaryComment> findRepliesByParentIds(List<Long> parentIds);
+    Long countParentComments(Long diaryId);
+}

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.lxdproject.lxd.diarycomment.entity.QDiaryComment;
 import org.lxdproject.lxd.diarycommentlike.entity.QDiaryCommentLike;
+import org.lxdproject.lxd.member.entity.QMember;
 
 import java.util.List;
 
@@ -14,11 +15,13 @@ public class DiaryCommentRepositoryImpl implements DiaryCommentRepositoryCustom 
     private final JPAQueryFactory queryFactory;
 
     QDiaryComment comment = QDiaryComment.diaryComment;
+    QMember member = QMember.member;
 
     @Override
     public List<DiaryComment> findParentComments(Long diaryId, int offset, int size) {
         return queryFactory
                 .selectFrom(comment)
+                .leftJoin(comment.member, member).fetchJoin()
                 .where(comment.diary.id.eq(diaryId)
                         .and(comment.parent.isNull()))
                 .orderBy(comment.createdAt.asc())
@@ -31,6 +34,8 @@ public class DiaryCommentRepositoryImpl implements DiaryCommentRepositoryCustom 
     public List<DiaryComment> findRepliesByParentIds(List<Long> parentIds) {
         return queryFactory
                 .selectFrom(comment)
+                .leftJoin(comment.member, member).fetchJoin()
+                .leftJoin(comment.parent).fetchJoin()
                 .where(comment.parent.id.in(parentIds))
                 .orderBy(comment.createdAt.asc())
                 .fetch();

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
@@ -21,7 +21,7 @@ public class DiaryCommentRepositoryImpl implements DiaryCommentRepositoryCustom 
                 .selectFrom(comment)
                 .where(comment.diary.id.eq(diaryId)
                         .and(comment.parent.isNull()))
-                .orderBy(comment.createdAt.desc())
+                .orderBy(comment.createdAt.asc())
                 .offset(offset)
                 .limit(size)
                 .fetch();

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryImpl.java
@@ -1,0 +1,48 @@
+package org.lxdproject.lxd.diarycomment.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+import org.lxdproject.lxd.diarycomment.entity.QDiaryComment;
+import org.lxdproject.lxd.diarycommentlike.entity.QDiaryCommentLike;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DiaryCommentRepositoryImpl implements DiaryCommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    QDiaryComment comment = QDiaryComment.diaryComment;
+
+    @Override
+    public List<DiaryComment> findParentComments(Long diaryId, int offset, int size) {
+        return queryFactory
+                .selectFrom(comment)
+                .where(comment.diary.id.eq(diaryId)
+                        .and(comment.parent.isNull()))
+                .orderBy(comment.createdAt.desc())
+                .offset(offset)
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<DiaryComment> findRepliesByParentIds(List<Long> parentIds) {
+        return queryFactory
+                .selectFrom(comment)
+                .where(comment.parent.id.in(parentIds))
+                .orderBy(comment.createdAt.asc())
+                .fetch();
+    }
+
+    @Override
+    public Long countParentComments(Long diaryId) {
+        return queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.diary.id.eq(diaryId)
+                        .and(comment.parent.isNull()))
+                .fetchOne();
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -197,13 +197,13 @@ public class DiaryCommentService {
         // hasNext는 부모 댓글 수 기준
         boolean hasNext = diaryCommentRepository.countParentComments(diaryId) > offset + size;
 
-        return PageResponse.<DiaryCommentResponseDTO.Comment>builder()
-                .totalElements((long) totalElements)
-                .contents(commentDTOs)
-                .page(page + 1)
-                .size(size)
-                .hasNext(hasNext)
-                .build();
+        return new PageResponse<>(
+                (long) totalElements,
+                commentDTOs,
+                page + 1,
+                size,
+                hasNext
+        );
     }
 
     @Transactional

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -61,7 +61,6 @@ public class DiaryCommentService {
         CommentPermission permission = diary.getCommentPermission();
 
         //권한 확인
-
         if (permission == CommentPermission.NONE && !commentOwner.equals(diaryOwner)) {
             throw new CommentHandler(ErrorStatus.COMMENT_PERMISSION_DENIED);
         }
@@ -77,9 +76,16 @@ public class DiaryCommentService {
             parent = diaryCommentRepository.findById(request.getParentId())
                     .orElseThrow(() -> new CommentHandler(ErrorStatus.PARENT_COMMENT_NOT_FOUND));
 
+            // depth를 1로만 제한
             if (parent.getParent() != null) {
                 throw new CommentHandler(ErrorStatus.COMMENT_DEPTH_EXCEEDED);
             }
+
+            // 삭제된 부모 댓글에는 대댓글 제한
+            if (parent.getDeletedAt() != null) {
+                throw new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND);
+            }
+
             parent.increaseReplyCount();
         }
 

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
@@ -11,8 +11,11 @@ import java.util.Optional;
 public interface DiaryCommentLikeRepository extends JpaRepository<DiaryCommentLike, Long> {
     Optional<DiaryCommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
 
-
-    @Query("SELECT l.comment.id FROM DiaryCommentLike l WHERE l.member.id = :memberId AND l.comment.id IN :commentIds")
+    @Query("""
+    SELECT l.comment.id FROM DiaryCommentLike l 
+    WHERE l.member.id = :memberId 
+    AND l.comment.id IN :commentIds
+""")
     List<Long> findLikedCommentIds(@Param("memberId") Long memberId, @Param("commentIds") List<Long> commentIds);
 
 }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #222 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기 댓글 조회시 누락 필드 추가 및 정렬, 쿼리 최적화

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
- 부모 댓글 페이징 조회 시 QueryDSL 사용으로 쿼리 최적화
- 자식 댓글(대댓글) 일괄 조회로 N+1 문제 제거
- 전체 댓글 ID를 기반으로 좋아요 여부를 한 번에 조회 (in 절)
- DTO 변환 시 불필요한 헬퍼 메서드 제거 → 서비스 내부에서 직접 변환
- totalElements는 `Diary.commentCount` 사용 (전체 댓글 수 표기를 위한 목적)
- hasNext는 부모 댓글 기준으로 계산
- 댓글과 답글 조회 정렬 기준을 오래된 순(createdAt ase)으로 변경

> 성능 개선
> - 부모 댓글만 페이징 대상으로 하여 쿼리 부하 감소
> - 자식 댓글과 좋아요 여부를 각각 한 번의 쿼리로 일괄 조회
> - 전체 댓글 수는 미리 카운트된 필드(`commentCount`)를 활용하여 추가 쿼리 제거
> - DTO 변환에서 불필요한 컨버터 클래스 없이 바로 처리하여 단순화


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 일기 댓글 목록이 표준 페이지 응답으로 제공됩니다(총 개수, 페이지, 페이지 크기, 다음 페이지 여부 포함).
  - 댓글은 생성일 오름차순으로 정렬됩니다.
  - 일기 댓글 조회의 page 기본값이 1로 변경되었습니다(1부터 시작).

- Refactor
  - 댓글 페이징 처리를 컨트롤러에서 서비스로 위임해 응답 형식을 통일하고 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->