### PR TITLE
[FIX] 조회 API의 정렬 수정

### DIFF
--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -48,7 +48,7 @@ public class CorrectionService {
         Diary diary = diaryRepository.findByIdAndDeletedAtIsNull(diaryId)
                 .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
         Page<Correction> correctionPage = correctionRepository.findByDiaryId(diaryId, pageable);
 
         Set<Long> likedIds = findLikedCorrectionIds(member, correctionPage.getContent());

--- a/src/main/java/org/lxdproject/lxd/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/org/lxdproject/lxd/friend/repository/FriendRequestRepository.java
@@ -30,6 +30,7 @@ SELECT new org.lxdproject.lxd.friend.dto.FriendResponseDTO(
 FROM FriendRequest fr
 JOIN fr.requester m
 WHERE fr.receiver = :receiver AND fr.status = :status
+ORDER BY fr.createdAt DESC
 """)
     Page<FriendResponseDTO> findReceivedRequestDTOs(@Param("receiver") Member receiver, @Param("status") FriendRequestStatus status, Pageable pageable);
     @Query("""
@@ -42,6 +43,7 @@ SELECT new org.lxdproject.lxd.friend.dto.FriendResponseDTO(
 FROM FriendRequest fr
 JOIN fr.receiver m
 WHERE fr.requester = :requester AND fr.status = :status
+ORDER BY fr.createdAt DESC
 """)
     Page<FriendResponseDTO> findSentRequestDTOs(@Param("requester") Member requester, @Param("status") FriendRequestStatus status, Pageable pageable);
 

--- a/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
+++ b/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
@@ -93,7 +93,7 @@ public class NotificationService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         Page<Notification> notificationPage = notificationRepository.findPageByMemberId(memberId, isRead, pageable);
 


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #227 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
조회시 화면설계서의 정렬 조건대로 수정

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
pageable의 sort.direction 또는 쿼리 DSL의 조건 코드를 변경했습니다.

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 알림 목록을 생성일 기준 최신순으로 정렬해 가장 최근 알림이 먼저 표시됩니다.
  - 보낸/받은 친구 요청 목록을 생성일 최신순으로 일관되게 표시합니다.
  - 교정 목록 페이지는 생성일 오름차순으로 정렬되어 첫 페이지에 오래된 항목이 먼저 나타납니다.
  - 정렬 기준 통일로 목록 탐색의 예측 가능성과 가독성이 개선되었습니다.
  - 페이지네이션 동작은 동일하며, 각 목록의 정렬만 변경되었습니다.
  - 최근 항목 확인이 쉬워져 알림·친구 요청 응답이 빨라집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->