### PR TITLE
[FIX] 알림 저장 후 flush 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
+++ b/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
@@ -62,6 +62,7 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
+        notificationRepository.flush();
 
         String senderUsername = sender.getUsername();
         String diaryTitle = getDiaryTitleIfExists(notification);


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #247 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
알림 저장 직후 Redis에 publish하면서 Subscriber가 해당 알림을 조회하지 못해 SSE 전송에 실패하는 문제가 발생함
JPA의 save()가 즉시 DB 반영을 보장하지 않기 때문에, flush()를 추가하여 이 문제를 해결함

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->

- NotificationService.saveAndPublishNotification() 에서 notificationRepository.flush() 추가
- 알림 저장 후 즉시 DB에 반영되도록 보장하여 Redis Subscriber에서 Notification을 정상 조회 가능하게 수정

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
