### PR TITLE
[FIX] 알림 전송 외 이벤트 발생시 flush 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
@@ -140,6 +140,8 @@ public class FriendService {
         // 친구 요청 알림 삭제
         long deleted = notificationRepository.deleteFriendRequestNotification(receiver.getId(), requester.getId());
         if (deleted > 0) {
+            notificationRepository.flush();
+
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
@@ -251,6 +253,8 @@ public class FriendService {
         // 친구 요청 알림 삭제
         long deleted = notificationRepository.deleteFriendRequestNotification(receiverId, requesterId);
         if (deleted > 0) {
+            notificationRepository.flush();
+
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
@@ -279,6 +283,8 @@ public class FriendService {
 
         long deleted = notificationRepository.deleteFriendRequestNotification(receiverId, requesterId);
         if (deleted > 0) {
+            notificationRepository.flush();
+
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {

--- a/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
+++ b/src/main/java/org/lxdproject/lxd/notification/service/NotificationService.java
@@ -146,6 +146,7 @@ public class NotificationService {
 
         if (!notification.isRead()) {
             notification.markAsRead();
+            notificationRepository.flush();
             sseEmitterService.sendNotificationReadUpdate(notification);
         }
 
@@ -168,7 +169,8 @@ public class NotificationService {
         for (Notification notification : unreadList) {
             notification.markAsRead();
         }
-
+        notificationRepository.flush();
+        
         sseEmitterService.sendAllReadUpdate(memberId);
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #247 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
알림 저장 직후 Redis에 publish하면서 Subscriber가 해당 알림을 조회하지 못해 SSE 전송에 실패하는 문제가 발생

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
친구 요청 수락 또는 거절시 알림 삭제될 때 flush 추가
알림 읽기 이벤트 발생시 flush 추가

> DB 반영이 완료된 이후에만 SSE로 전파되며, 데이터 불일치나 트랜잭션 롤백 시 오작동 없이 안전하게 동작하도록 해야 함
> 따라서 이후 SSE 전송을 @TransactionalEventListener(phase = AFTER_COMMIT) 또는 TransactionSynchronization에 위임하도록 수정할 계획


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 친구 요청 수락/거절/취소 시 관련 알림이 즉시 반영되지 않거나 지연 표시되던 문제를 개선했습니다.
  * 알림 읽음 처리 후 실시간 업데이트(SSE)가 간헐적으로 누락되던 현상을 수정했습니다.
  * 여러 알림을 일괄 읽음 처리할 때 상태 반영이 지연되던 문제를 해결했습니다.
  * 전반적으로 알림 읽음/삭제 동기화 신뢰성을 높여 실시간 표시 정확도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->