### PR TITLE
[FIX] 프로필 이미지 삭제 요청시 Null로 저장

### DIFF
--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -79,6 +79,7 @@ public class MemberController implements MemberApi {
 
     @Override
     public ApiResponse<String> deleteProfileImage() {
-        return ApiResponse.onSuccess(memberService.resetToDefaultProfileImage());
+        memberService.deleteProfileImage();
+        return ApiResponse.onSuccess("프로필 이미지가 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #257 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
멤버의 프로필 이미지 필드를 nullable = True로 설정하여 삭제시 null로 저장

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
