### PR TITLE
[FEATURE] 댓글 삭제 권한 검증 추가 및 Guard 적용

### DIFF
--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -78,6 +78,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"COMMENT4002","댓글을 찾을 수 없습니다."),
     COMMENT_DEPTH_EXCEEDED(HttpStatus.FORBIDDEN,"COMMENT4003", "댓글은 한 단계까지만 허용됩니다."),
     COMMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "COMMENT4004", "댓글 작성 권한이 없습니다."),
+    COMMENT_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "COMMENT4005", "댓글 삭제 권한이 없습니다."),
 
     // S3 관련 에러
     FILE_STREAM_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"S34001","파일 스트림 읽기 실패"),

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -7,6 +7,7 @@ import org.lxdproject.lxd.authz.model.Permit;
 import org.lxdproject.lxd.authz.policy.CommentPermissionPolicy;
 import org.lxdproject.lxd.authz.policy.DiaryVisibilityPolicy;
 import org.lxdproject.lxd.correction.entity.Correction;
+import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,20 @@ public class PermissionGuard {
         Permit permit = policy.canCreate(writerId, diary, areFriends);
         if (permit == Permit.DENY) {
             throw new DiaryHandler(ErrorStatus.COMMENT_PERMISSION_DENIED);
+        }
+    }
+
+    public void canDeleteDiaryComment(Long requesterId, DiaryComment comment) {
+        Permit permit = policy.canDelete(requesterId, comment);
+        if (permit == Permit.DENY) {
+            throw new DiaryHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
+        }
+    }
+
+    public void canDeleteCorrectionComment(Long requesterId, CorrectionComment comment) {
+        Permit permit = policy.canDelete(requesterId, comment);
+        if (permit == Permit.DENY) {
+            throw new DiaryHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -1,6 +1,7 @@
 package org.lxdproject.lxd.authz.guard;
 
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.model.Permit;
@@ -33,21 +34,21 @@ public class PermissionGuard {
     public void canCreateDiaryComment(Long writerId, Diary diary, boolean areFriends) {
         Permit permit = policy.canCreate(writerId, diary, areFriends);
         if (permit == Permit.DENY) {
-            throw new DiaryHandler(ErrorStatus.COMMENT_PERMISSION_DENIED);
+            throw new CommentHandler(ErrorStatus.COMMENT_PERMISSION_DENIED);
         }
     }
 
     public void canDeleteDiaryComment(Long requesterId, DiaryComment comment) {
         Permit permit = policy.canDelete(requesterId, comment);
         if (permit == Permit.DENY) {
-            throw new DiaryHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
+            throw new CommentHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
         }
     }
 
     public void canDeleteCorrectionComment(Long requesterId, CorrectionComment comment) {
         Permit permit = policy.canDelete(requesterId, comment);
         if (permit == Permit.DENY) {
-            throw new DiaryHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
+            throw new CommentHandler(ErrorStatus.COMMENT_DELETE_PERMISSION_DENIED);
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/authz/policy/CommentPermissionPolicy.java
+++ b/src/main/java/org/lxdproject/lxd/authz/policy/CommentPermissionPolicy.java
@@ -1,7 +1,9 @@
 package org.lxdproject.lxd.authz.policy;
 
 import org.lxdproject.lxd.authz.model.Permit;
+import org.lxdproject.lxd.correctioncomment.entity.CorrectionComment;
 import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,4 +24,18 @@ public class CommentPermissionPolicy {
             default -> { return Permit.DENY; }
         }
     }
+
+    private Permit canDeleteInternal(Long requesterId, Long writerId) {
+        if (requesterId == null) return Permit.DENY;
+        return requesterId.equals(writerId) ? Permit.ALLOW : Permit.DENY;
+    }
+
+    public Permit canDelete(Long requesterId, DiaryComment comment) {
+        return canDeleteInternal(requesterId, comment.getMember().getId());
+    }
+
+    public Permit canDelete(Long requesterId, CorrectionComment comment) {
+        return canDeleteInternal(requesterId, comment.getMember().getId());
+    }
+
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -204,15 +204,18 @@ public class DiaryCommentService {
 
     @Transactional
     public DiaryCommentDeleteResponseDTO deleteComment(Long diaryId, Long commentId) {
+        Long requesterId = SecurityUtil.getCurrentMemberId();
         Diary diary = diaryRepository.findByIdAndDeletedAtIsNull(diaryId)
                 .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
         DiaryComment comment = diaryCommentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
 
+        // 삭제 권한 검증
+        permissionGuard.canDeleteDiaryComment(requesterId, comment);
+
         comment.softDelete();
         diary.decreaseCommentCount();
-
 
         return DiaryCommentDeleteResponseDTO.from(comment);
     }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
closed #268 

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
DiaryComment 또는 CorrectionComment 삭제 시 작성자 본인만 삭제 가능하도록 권한 검증 로직을 추가
기존 서비스 내 직접 검증 로직을 제거하고 PermissionGuard → CommentPermissionPolicy 구조로 통일함

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
CommentPermissionPolicy

- canDeleteInternal 메서드 추가하여 중복 제거
- canDelete(DiaryComment), canDelete(CorrectionComment) 메서드 추가

PermissionGuard

- canDeleteDiaryComment, canDeleteCorrectionComment 메서드 추가

DiaryCommentService, CorrectionCommentService

- 삭제 시 permissionGuard 검증 로직 호출
- 서비스 코드에서 직접 작성자 검증 로직 제거

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 댓글 삭제 권한 체크 강화: 본인 댓글만 삭제 가능. 권한 없을 시 403과 “댓글 삭제 권한이 없습니다.” 안내가 표시됩니다.
* Changes
  * 일기 댓글 삭제 API 응답이 간소화되었습니다(삭제 성공 시 본문 없이 처리). 삭제 동작과 댓글 수 집계에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->