### PR TITLE
[FEATURE] 회원 탈퇴 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ dependencies {
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 
+	// shed lock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.12.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.12.0'
+
 	// Apache Commons Text
 	implementation 'org.apache.commons:commons-text:1.10.0'
 }

--- a/src/main/java/org/lxdproject/lxd/LxdApplication.java
+++ b/src/main/java/org/lxdproject/lxd/LxdApplication.java
@@ -3,10 +3,11 @@ package org.lxdproject.lxd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
-
+@EnableScheduling
 public class LxdApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/ExceptionAdvice.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/exception/ExceptionAdvice.java
@@ -8,10 +8,13 @@ import org.lxdproject.lxd.apiPayload.code.dto.ErrorReasonDTO;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.GeneralException;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -78,6 +81,24 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 e, body, HttpHeaders.EMPTY,
                 reason.getHttpStatus(), new ServletWebRequest(request)
         );
+    }
+
+    //
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<Object> handleUnauthorizedException(AuthenticationException e, WebRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(
+                ErrorStatus.INVALID_CREDENTIALS.getCode(),
+                ErrorStatus.INVALID_CREDENTIALS.getMessage(),
+                null
+        );
+
+        return super.handleExceptionInternal(
+                e, body, HttpHeaders.EMPTY,
+                ErrorStatus.INVALID_CREDENTIALS.getHttpStatus(), request
+        );
+
     }
 
     // 모든 기타 예외 처리 (예상치 못한 에러)

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -52,6 +52,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTHENTICATION_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4320", "인증 정보를 찾을 수 없습니다."),
     INVALID_AUTHENTICATION_INFO(HttpStatus.FORBIDDEN, "AUTH4321", "인증된 사용자 정보가 올바르지 않습니다."),
     NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN,"AUTH4001","해당 리소스의 작성자가 아닙니다. 권한이 없습니다."),
+    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4330", "탈퇴한 사용자는 서비스를 이용할 수 없습니다."),
 
     // 일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND,"DIARY4001","일기를 찾을 수 없습니다."),

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_AUTHENTICATION_INFO(HttpStatus.FORBIDDEN, "AUTH4321", "인증된 사용자 정보가 올바르지 않습니다."),
     NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN,"AUTH4001","해당 리소스의 작성자가 아닙니다. 권한이 없습니다."),
     WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4330", "탈퇴한 사용자는 서비스를 이용할 수 없습니다."),
+    NO_WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4331", "탈퇴한 사용자가 아닙니다."),
 
     // 일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND,"DIARY4001","일기를 찾을 수 없습니다."),

--- a/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/lxdproject/lxd/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,8 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4315", "올바르지 않은 닉네임 형식입니다."),
     INVALID_PROFILE_DATA(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임을 {\"nickname\":\"수정할 닉네임\"} 형식으로 요청해주세요."),
     NEW_PASSWORDS_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "MEMBER4316", "새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다"),
+    RESOURCE_OWNER_WITHDRAWN(HttpStatus.FORBIDDEN, "MEMBER4320", "리소스 소유자가 탈퇴하여 접근할 수 없습니다."),
+    TARGET_USER_WITHDRAWN(HttpStatus.FORBIDDEN, "AUTH4321", "해당 유저가 탈퇴하였습니다."),
 
     // 친구 관련 에러
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, "FRIEND4314", "이미 친구 요청을 보냈습니다."),
@@ -52,7 +54,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTHENTICATION_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4320", "인증 정보를 찾을 수 없습니다."),
     INVALID_AUTHENTICATION_INFO(HttpStatus.FORBIDDEN, "AUTH4321", "인증된 사용자 정보가 올바르지 않습니다."),
     NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN,"AUTH4001","해당 리소스의 작성자가 아닙니다. 권한이 없습니다."),
-    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4330", "탈퇴한 사용자는 서비스를 이용할 수 없습니다."),
+    SELF_WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4330", "탈퇴한 사용자는 서비스를 이용할 수 없습니다."),
     NO_WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH4331", "탈퇴한 사용자가 아닙니다."),
 
     // 일기 관련 에러

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthApi.java
@@ -85,5 +85,13 @@ public interface AuthApi {
     })
     ApiResponse<String> logout(@RequestBody @Valid AuthRequestDTO.LogoutRequestDTO logoutRequestDTO);
 
+    @PatchMapping("/recover")
+    @Operation(summary = "회원 탈퇴 복구 API", description = "회원의 deletedAt를 null로 바꾸고 관련 엔티티들의 status도 변경합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "사용자 정보 요청 실패"),
+    })
+    ApiResponse<String> recover();
 }
 

--- a/src/main/java/org/lxdproject/lxd/auth/controller/AuthController.java
+++ b/src/main/java/org/lxdproject/lxd/auth/controller/AuthController.java
@@ -77,5 +77,13 @@ public class AuthController implements AuthApi {
 
     }
 
+    @Override
+    public ApiResponse<String> recover() {
+
+        authService.recover();
+
+        return ApiResponse.onSuccess("계정이 복구 되었습니다. 재로그인 해주세요");
+    }
+
 
 }

--- a/src/main/java/org/lxdproject/lxd/auth/converter/AuthConverter.java
+++ b/src/main/java/org/lxdproject/lxd/auth/converter/AuthConverter.java
@@ -6,7 +6,7 @@ import org.lxdproject.lxd.member.entity.Member;
 
 public class AuthConverter {
 
-    public static AuthResponseDTO.LoginResponseDTO toLoginResponseDTO(String accessToken, String refreshToken, Member member) {
+    public static AuthResponseDTO.LoginResponseDTO toLoginResponseDTO(String accessToken, String refreshToken, Member member, Boolean isWithDrawn) {
         return AuthResponseDTO.LoginResponseDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -19,6 +19,7 @@ public class AuthConverter {
                         .nativeLanguage(member.getNativeLanguage().name())
                         .studyLanguage(member.getLanguage().name())
                         .build())
+                .isWithdrawn(isWithDrawn)
                 .build();
     }
 

--- a/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
@@ -21,6 +21,9 @@ public class AuthResponseDTO {
         @Schema(description = "리프레쉬 토큰")
         private String refreshToken;
 
+        @Schema(description = "탈퇴한 사용자인지 여부")
+        private Boolean isWithdrawn;
+
         @Schema(description = "로그인한 멤버 정보")
         private MemberDTO member;
 

--- a/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/AuthResponseDTO.java
@@ -73,6 +73,9 @@ public class AuthResponseDTO {
         @Schema(description = "리프레쉬 토큰")
         private String refreshToken;
 
+        @Schema(description = "탈퇴한 사용자인지 여부")
+        private Boolean isWithdrawn;
+
         @Schema(description = "로그인한 멤버 정보")
         private MemberDTO member;
 

--- a/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
@@ -34,6 +34,10 @@ public class CustomUserDetails implements UserDetails {
         return member;
     }
 
+    public boolean isDeleted() {
+        return member.isDeleted();
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();

--- a/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
@@ -1,0 +1,82 @@
+package org.lxdproject.lxd.auth.dto;
+
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.entity.enums.Role;
+import org.lxdproject.lxd.member.repository.MemberRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    public Long getMemberId() {
+        return member.getId();
+    }
+
+    public String getMemberEmail(){
+        return member.getEmail();
+    }
+
+    public Role getRole() {
+        return member.getRole();
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+
+                return member.getRole().toString();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
+++ b/src/main/java/org/lxdproject/lxd/auth/dto/CustomUserDetails.java
@@ -6,6 +6,7 @@ import org.lxdproject.lxd.member.repository.MemberRepository;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -36,6 +37,10 @@ public class CustomUserDetails implements UserDetails {
 
     public boolean isDeleted() {
         return member.isDeleted();
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return member.getDeletedAt();
     }
 
     @Override

--- a/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
+++ b/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
@@ -26,9 +26,11 @@ public class WithdrawnAccountFilter extends OncePerRequestFilter {
         // 탈퇴 상태인 경우
         if (auth != null && auth.getPrincipal() instanceof CustomUserDetails principal) {
             if (principal.isDeleted()) {
-                //TODO 복구 로직인지 검증하는 부분 추가하기
+                String requestURI = request.getRequestURI();
 
-                throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+                if (!requestURI.startsWith("/auth/recover")) {
+                    throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+                }
             }
         }
 

--- a/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
+++ b/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
@@ -29,7 +29,7 @@ public class WithdrawnAccountFilter extends OncePerRequestFilter {
                 String requestURI = request.getRequestURI();
 
                 if (!requestURI.startsWith("/auth/recover")) {
-                    throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+                    throw new AuthHandler(ErrorStatus.SELF_WITHDRAWN_USER);
                 }
             }
         }

--- a/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
+++ b/src/main/java/org/lxdproject/lxd/auth/filter/WithdrawnAccountFilter.java
@@ -1,0 +1,37 @@
+package org.lxdproject.lxd.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.auth.dto.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class WithdrawnAccountFilter extends OncePerRequestFilter {
+
+    // 계정 복구 api 엔드포인트
+    private static final String RECOVER_API = "/auth/recover";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        // 탈퇴 상태인 경우
+        if (auth != null && auth.getPrincipal() instanceof CustomUserDetails principal) {
+            if (principal.isDeleted()) {
+                //TODO 복구 로직인지 검증하는 부분 추가하기
+
+                throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
@@ -318,6 +318,9 @@ public class AuthService {
         }
 
         redisService.deleteRefreshToken(refreshToken);
+
+        // 현재 스레드에서 SecurityContext, Authentication, Principal 제거
+        SecurityContextHolder.clearContext();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/AuthService.java
@@ -35,6 +35,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @Service
@@ -72,10 +74,20 @@ public class AuthService {
 
         redisService.setRefreshToken(refreshToken, customUserDetails.getMemberEmail(), Duration.ofDays(7L));
 
+        Boolean isWithdrawn = false;
+
+
+        if(customUserDetails.getDeletedAt() != null &&
+                ChronoUnit.DAYS.between(customUserDetails.getDeletedAt(), LocalDateTime.now()) < 30) {
+
+            isWithdrawn = true;
+        }
+
         return AuthConverter.toLoginResponseDTO(
                 accessToken,
                 refreshToken,
-                customUserDetails.getMember()
+                customUserDetails.getMember(),
+                isWithdrawn
         );
     }
 

--- a/src/main/java/org/lxdproject/lxd/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/lxdproject/lxd/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package org.lxdproject.lxd.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.auth.dto.CustomUserDetails;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        // 1. 아이디(이메일) 검사
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다.: " + username));
+
+        // 2. 조회된 Member 엔티티를 바탕으로 CustomUserDetails 객체를 생성하여 반환
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -26,7 +26,7 @@ public class PermissionGuard {
         boolean areFriends = viewerId != null && friendshipQueryPort.areFriends(viewerId, ownerId);
 
         Permit permit = diaryVisibilityPolicy.canView(viewerId, diary, areFriends);
-        if (permit == Permit.DENY) {
+        if (permit == Permit.DENY || permit == Permit.WITHDRAWN) {
             throw new DiaryHandler(ErrorStatus.DIARY_PERMISSION_DENIED);
         }
     }

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -57,6 +57,14 @@ public class PermissionGuard {
         }
     }
 
+    public void canViewFriendList(Member member) {
+        Permit permit = friendPolicy.validateDeletedMember(member);
+        if(permit == Permit.WITHDRAWN){
+            throw new MemberHandler(ErrorStatus.TARGET_USER_WITHDRAWN);
+        }
+
+    }
+
     public void canSendFriendRequest(Member request, Member receiver) {
 
         Permit permit = friendPolicy.validateDeletedMember(request, receiver);

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -1,6 +1,7 @@
 package org.lxdproject.lxd.authz.guard;
 
 import lombok.RequiredArgsConstructor;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
@@ -29,8 +30,12 @@ public class PermissionGuard {
         boolean areFriends = viewerId != null && friendshipQueryPort.areFriends(viewerId, ownerId);
 
         Permit permit = diaryVisibilityPolicy.canView(viewerId, diary, areFriends);
-        if (permit == Permit.DENY || permit == Permit.WITHDRAWN) {
+        if (permit == Permit.DENY) {
             throw new DiaryHandler(ErrorStatus.DIARY_PERMISSION_DENIED);
+        }
+
+        if (permit == Permit.WITHDRAWN){
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
         }
     }
 
@@ -59,7 +64,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(request, receiver);
         if(permit == Permit.WITHDRAWN) {
-            throw new FriendHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
         }
 
         permit = friendPolicy.validateSameMember(request, receiver);
@@ -78,7 +83,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(request, receiver);
         if(permit == Permit.WITHDRAWN) {
-            throw new FriendHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
         }
 
         permit = friendPolicy.validateSameMember(request, receiver);
@@ -97,7 +102,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(current, target);
         if(permit == Permit.WITHDRAWN) {
-            throw new FriendHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
+++ b/src/main/java/org/lxdproject/lxd/authz/guard/PermissionGuard.java
@@ -1,10 +1,7 @@
 package org.lxdproject.lxd.authz.guard;
 
 import lombok.RequiredArgsConstructor;
-import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
-import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
-import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
-import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.*;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.model.Permit;
 import org.lxdproject.lxd.authz.policy.CommentPermissionPolicy;
@@ -35,7 +32,7 @@ public class PermissionGuard {
         }
 
         if (permit == Permit.WITHDRAWN){
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.RESOURCE_OWNER_WITHDRAWN);
         }
     }
 
@@ -64,7 +61,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(request, receiver);
         if(permit == Permit.WITHDRAWN) {
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.TARGET_USER_WITHDRAWN);
         }
 
         permit = friendPolicy.validateSameMember(request, receiver);
@@ -83,7 +80,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(request, receiver);
         if(permit == Permit.WITHDRAWN) {
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.TARGET_USER_WITHDRAWN);
         }
 
         permit = friendPolicy.validateSameMember(request, receiver);
@@ -102,7 +99,7 @@ public class PermissionGuard {
 
         Permit permit = friendPolicy.validateDeletedMember(current, target);
         if(permit == Permit.WITHDRAWN) {
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.TARGET_USER_WITHDRAWN);
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/authz/model/Permit.java
+++ b/src/main/java/org/lxdproject/lxd/authz/model/Permit.java
@@ -1,5 +1,5 @@
 package org.lxdproject.lxd.authz.model;
 
 public enum Permit {
-    ALLOW, DENY
+    ALLOW, DENY, WITHDRAWN
 }

--- a/src/main/java/org/lxdproject/lxd/authz/policy/DiaryVisibilityPolicy.java
+++ b/src/main/java/org/lxdproject/lxd/authz/policy/DiaryVisibilityPolicy.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 public class DiaryVisibilityPolicy {
     public Permit canView(Long viewerId, Diary diary, boolean areFriends) {
         Long ownerId = diary.getMember().getId();
+        if (diary.getMember().isDeleted()) return Permit.WITHDRAWN;
+
         if (viewerId != null && viewerId.equals(ownerId)) return Permit.ALLOW;
 
         return switch (diary.getVisibility()) {

--- a/src/main/java/org/lxdproject/lxd/authz/policy/FriendPolicy.java
+++ b/src/main/java/org/lxdproject/lxd/authz/policy/FriendPolicy.java
@@ -1,0 +1,54 @@
+package org.lxdproject.lxd.authz.policy;
+
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.authz.model.Permit;
+import org.lxdproject.lxd.friend.repository.FriendRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FriendPolicy {
+
+    private final FriendRepository friendRepository;
+
+    public FriendPolicy(FriendRepository friendRepository) {
+        this.friendRepository = friendRepository;
+    }
+
+    // 동일 인물인지 확인
+    public Permit validateSameMember(Member memberA, Member memberB) {
+        if (memberA == null || memberB == null)
+            throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);
+
+        if(memberA.getId().equals(memberB.getId())) return Permit.DENY;
+        return Permit.ALLOW;
+    }
+
+    // 이미 친구인지 확인
+    public Permit validateFriends(Member memberA, Member memberB) {
+        if (memberA == null || memberB == null)
+            throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);
+
+        boolean areFriends = friendRepository.areFriends(memberA.getId(), memberB.getId());
+
+        if (areFriends) return Permit.DENY;
+        return Permit.ALLOW;
+    }
+
+    // 탈퇴한 유저인지 확인
+    public Permit validateDeletedMember(Member memberA, Member memberB) {
+        if (memberA == null || memberB == null)
+            throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);
+
+        boolean isDeleted = false;
+
+        if(memberA.isDeleted() || memberB.isDeleted()) {
+            isDeleted = true;
+        }
+
+        if (isDeleted) return Permit.WITHDRAWN;
+        return Permit.ALLOW;
+    }
+
+}

--- a/src/main/java/org/lxdproject/lxd/authz/policy/FriendPolicy.java
+++ b/src/main/java/org/lxdproject/lxd/authz/policy/FriendPolicy.java
@@ -37,6 +37,15 @@ public class FriendPolicy {
     }
 
     // 탈퇴한 유저인지 확인
+    public Permit validateDeletedMember(Member member){
+        if(member == null || member.isDeleted()){
+            return Permit.WITHDRAWN;
+        }
+        return Permit.ALLOW;
+    }
+
+
+
     public Permit validateDeletedMember(Member memberA, Member memberB) {
         if (memberA == null || memberB == null)
             throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);

--- a/src/main/java/org/lxdproject/lxd/authz/predicate/VisibilityPredicates.java
+++ b/src/main/java/org/lxdproject/lxd/authz/predicate/VisibilityPredicates.java
@@ -16,7 +16,8 @@ public class VisibilityPredicates {
         BooleanExpression isFriends = (viewerId != null && friendIds != null && !friendIds.isEmpty())
                 ? D.visibility.eq(Visibility.FRIENDS).and(D.member.id.in(friendIds))
                 : Expressions.FALSE;
-        return isPublic.or(isFriends).or(isMine);
+        BooleanExpression isAuthorNotDeleted = D.member.isNotNull().and(D.member.deletedAt.isNull());
+        return isPublic.or(isFriends).or(isMine).or(isAuthorNotDeleted);
     }
 
     // 내 글 제외

--- a/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileDTO.java
+++ b/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileDTO.java
@@ -1,16 +1,15 @@
 package org.lxdproject.lxd.common.dto;
 
 import lombok.Builder;
-import lombok.Getter;
 import org.lxdproject.lxd.member.entity.Member;
 
 @Builder
-public record MemberProfileView(Long id, String username, String nickname, String profileImage) {
-    public static MemberProfileView from(Member member) {
+public record MemberProfileDTO(Long id, String username, String nickname, String profileImage) {
+    public static MemberProfileDTO from(Member member) {
         if (member.isDeleted()) {
-            return new MemberProfileView(null, null, "탈퇴한 사용자", null);
+            return new MemberProfileDTO(null, null, "탈퇴한 사용자", null);
         }
-        return new MemberProfileView(
+        return new MemberProfileDTO(
                 member.getId(),
                 member.getUsername(),
                 member.getNickname(),

--- a/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileDTO.java
+++ b/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileDTO.java
@@ -6,7 +6,7 @@ import org.lxdproject.lxd.member.entity.Member;
 @Builder
 public record MemberProfileDTO(Long id, String username, String nickname, String profileImage) {
     public static MemberProfileDTO from(Member member) {
-        if (member.isDeleted()) {
+        if (member == null || member.isDeleted()) {
             return new MemberProfileDTO(null, null, "탈퇴한 사용자", null);
         }
         return new MemberProfileDTO(

--- a/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileView.java
+++ b/src/main/java/org/lxdproject/lxd/common/dto/MemberProfileView.java
@@ -1,0 +1,20 @@
+package org.lxdproject.lxd.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.lxdproject.lxd.member.entity.Member;
+
+@Builder
+public record MemberProfileView(Long id, String username, String nickname, String profileImage) {
+    public static MemberProfileView from(Member member) {
+        if (member.isDeleted()) {
+            return new MemberProfileView(null, null, "탈퇴한 사용자", null);
+        }
+        return new MemberProfileView(
+                member.getId(),
+                member.getUsername(),
+                member.getNickname(),
+                member.getProfileImg()
+        );
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/common/entity/BaseEntity.java
+++ b/src/main/java/org/lxdproject/lxd/common/entity/BaseEntity.java
@@ -31,6 +31,10 @@ public abstract class BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void softDelete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
     public void restore() {
         this.deletedAt = null;
     }

--- a/src/main/java/org/lxdproject/lxd/config/SchedulerConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/SchedulerConfig.java
@@ -1,0 +1,28 @@
+package org.lxdproject.lxd.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
+public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .withTableName("shed_lock")
+                        .usingDbTime()
+                        .build()
+        );
+    }
+}

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -52,6 +54,11 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final SecurityExceptionHandler securityExceptionHandler;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.SecurityExceptionHandler;
+import org.lxdproject.lxd.auth.filter.WithdrawnAccountFilter;
 import org.lxdproject.lxd.config.properties.UrlProperties;
 import org.lxdproject.lxd.config.security.jwt.JwtAuthenticationFilter;
 import org.lxdproject.lxd.config.security.jwt.JwtTokenProvider;
@@ -77,6 +78,7 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new WithdrawnAccountFilter(), JwtAuthenticationFilter.class)
                 .addFilterBefore(securityExceptionHandler, JwtAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/org/lxdproject/lxd/config/security/SecurityUtil.java
+++ b/src/main/java/org/lxdproject/lxd/config/security/SecurityUtil.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.config.security;
 
 import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.auth.dto.CustomUserDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -23,9 +24,10 @@ public class SecurityUtil {
             throw new AuthHandler(ErrorStatus.AUTHENTICATION_INFO_NOT_FOUND);
         }
 
+        CustomUserDetails customUserDetails = authentication.getPrincipal() instanceof CustomUserDetails ? (CustomUserDetails) authentication.getPrincipal() : null;
+
         try {
-            String principalStr = authentication.getName();
-            return Long.valueOf(principalStr);
+            return customUserDetails.getMemberId();
         } catch (Exception e) {
             throw new AuthHandler(ErrorStatus.INVALID_ACCESS_TOKEN);
         }

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -7,7 +7,6 @@ import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.diary.entity.Diary;
-import org.lxdproject.lxd.member.entity.Member;
 
 
 public class CorrectionResponseDTO {
@@ -25,31 +24,13 @@ public class CorrectionResponseDTO {
         private Long correctionId;
         private Long diaryId;
         private String createdAt;
-        private MemberProfileDTO member;
+        private MemberProfileDTO memberProfile;
         private String original;
         private String corrected;
         private String commentText;
         private int likeCount;
         private int commentCount;
         private boolean isLikedByMe;
-    }
-
-    @Getter
-    @Builder
-    public static class MemberInfo {
-        private Long memberId;
-        private String username;
-        private String nickname;
-        private String profileImageUrl;
-
-        public static MemberInfo from(Member member) {
-            return MemberInfo.builder()
-                    .memberId(member.getId())
-                    .username(member.getUsername())
-                    .nickname(member.getNickname())
-                    .profileImageUrl(member.getProfileImg())
-                    .build();
-        }
     }
 
     @Getter
@@ -109,7 +90,7 @@ public class CorrectionResponseDTO {
     @Getter
     @Builder
     public static class ProvidedCorrectionsResponseDTO {
-        private MemberProfileDTO memberProfileDTO;
+        private MemberProfileDTO memberProfile;
         private PageDTO<ProvidedCorrectionItem> corrections;
     }
 

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.correction.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileView;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
@@ -24,7 +25,7 @@ public class CorrectionResponseDTO {
         private Long correctionId;
         private Long diaryId;
         private String createdAt;
-        private MemberInfo member;
+        private MemberProfileView member;
         private String original;
         private String corrected;
         private String commentText;
@@ -108,7 +109,7 @@ public class CorrectionResponseDTO {
     @Getter
     @Builder
     public static class ProvidedCorrectionsResponseDTO {
-        private MemberInfo member;
+        private MemberProfileView memberProfileView;
         private PageDTO<ProvidedCorrectionItem> corrections;
     }
 

--- a/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correction/dto/CorrectionResponseDTO.java
@@ -2,7 +2,7 @@ package org.lxdproject.lxd.correction.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.lxdproject.lxd.common.dto.MemberProfileView;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.correction.entity.Correction;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
@@ -25,7 +25,7 @@ public class CorrectionResponseDTO {
         private Long correctionId;
         private Long diaryId;
         private String createdAt;
-        private MemberProfileView member;
+        private MemberProfileDTO member;
         private String original;
         private String corrected;
         private String commentText;
@@ -109,7 +109,7 @@ public class CorrectionResponseDTO {
     @Getter
     @Builder
     public static class ProvidedCorrectionsResponseDTO {
-        private MemberProfileView memberProfileView;
+        private MemberProfileDTO memberProfileDTO;
         private PageDTO<ProvidedCorrectionItem> corrections;
     }
 

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.correction.service;
 
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
+import org.lxdproject.lxd.common.dto.MemberProfileView;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.correctionlike.entity.MemberSavedCorrection;
@@ -64,7 +65,7 @@ public class CorrectionService {
                         .likeCount(correction.getLikeCount())
                         .commentCount(correction.getCommentCount())
                         .isLikedByMe(likedIds.contains(correction.getId()))
-                        .member(CorrectionResponseDTO.MemberInfo.from(correction.getAuthor()))
+                        .member(MemberProfileView.from(correction.getAuthor()))
                         .build())
                 .toList();
 
@@ -165,11 +166,11 @@ public class CorrectionService {
                 .likeCount(saved.getLikeCount())
                 .commentCount(saved.getCommentCount())
                 .isLikedByMe(false)
-                .member(CorrectionResponseDTO.MemberInfo.builder()
-                        .memberId(member.getId())
+                .member(MemberProfileView.builder()
+                        .id(member.getId())
                         .username(member.getUsername())
                         .nickname(member.getNickname())
-                        .profileImageUrl(member.getProfileImg())
+                        .profileImage(member.getProfileImg())
                         .build())
                 .build();
     }
@@ -195,7 +196,7 @@ public class CorrectionService {
         );
 
         return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
-                .member(CorrectionResponseDTO.MemberInfo.from(member))
+                .memberProfileView(MemberProfileView.from(member))
                 .corrections(pageDTO)
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -65,7 +65,7 @@ public class CorrectionService {
                         .likeCount(correction.getLikeCount())
                         .commentCount(correction.getCommentCount())
                         .isLikedByMe(likedIds.contains(correction.getId()))
-                        .member(MemberProfileDTO.from(correction.getAuthor()))
+                        .memberProfile(MemberProfileDTO.from(correction.getAuthor()))
                         .build())
                 .toList();
 
@@ -166,7 +166,7 @@ public class CorrectionService {
                 .likeCount(saved.getLikeCount())
                 .commentCount(saved.getCommentCount())
                 .isLikedByMe(false)
-                .member(MemberProfileDTO.builder()
+                .memberProfile(MemberProfileDTO.builder()
                         .id(member.getId())
                         .username(member.getUsername())
                         .nickname(member.getNickname())
@@ -196,7 +196,7 @@ public class CorrectionService {
         );
 
         return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
-                .memberProfileDTO(MemberProfileDTO.from(member))
+                .memberProfile(MemberProfileDTO.from(member))
                 .corrections(pageDTO)
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correction/service/CorrectionService.java
@@ -2,7 +2,7 @@ package org.lxdproject.lxd.correction.service;
 
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
-import org.lxdproject.lxd.common.dto.MemberProfileView;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.correctionlike.entity.MemberSavedCorrection;
@@ -65,7 +65,7 @@ public class CorrectionService {
                         .likeCount(correction.getLikeCount())
                         .commentCount(correction.getCommentCount())
                         .isLikedByMe(likedIds.contains(correction.getId()))
-                        .member(MemberProfileView.from(correction.getAuthor()))
+                        .member(MemberProfileDTO.from(correction.getAuthor()))
                         .build())
                 .toList();
 
@@ -166,7 +166,7 @@ public class CorrectionService {
                 .likeCount(saved.getLikeCount())
                 .commentCount(saved.getCommentCount())
                 .isLikedByMe(false)
-                .member(MemberProfileView.builder()
+                .member(MemberProfileDTO.builder()
                         .id(member.getId())
                         .username(member.getUsername())
                         .nickname(member.getNickname())
@@ -196,7 +196,7 @@ public class CorrectionService {
         );
 
         return CorrectionResponseDTO.ProvidedCorrectionsResponseDTO.builder()
-                .memberProfileView(MemberProfileView.from(member))
+                .memberProfileDTO(MemberProfileDTO.from(member))
                 .corrections(pageDTO)
                 .build();
     }

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -12,7 +12,7 @@ import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 @NoArgsConstructor
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private MemberProfileDTO memberProfileDTO;
+    private MemberProfileDTO memberProfile;
     private String content;
     private String createdAt;
 }

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -4,10 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.lxdproject.lxd.common.dto.MemberProfileView;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 
 @Getter
 @Builder
@@ -15,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private MemberProfileView memberProfileView;
+    private MemberProfileDTO memberProfileDTO;
     private String content;
     private String createdAt;
 }

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/dto/CorrectionCommentResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.lxdproject.lxd.common.dto.MemberProfileView;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,10 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CorrectionCommentResponseDTO {
     private Long commentId;
-    private Long memberId;
-    private String username;
-    private String nickname;
-    private String profileImage;
+    private MemberProfileView memberProfileView;
     private String content;
     private String createdAt;
 }

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -7,6 +7,7 @@ import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.guard.PermissionGuard;
+import org.lxdproject.lxd.common.dto.MemberProfileView;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.config.security.SecurityUtil;
@@ -72,10 +73,7 @@ public class CorrectionCommentService {
 
         return CorrectionCommentResponseDTO.builder()
                 .commentId(saved.getId())
-                .memberId(member.getId())
-                .username(member.getUsername())
-                .nickname(member.getNickname())
-                .profileImage(member.getProfileImg())
+                .memberProfileView(MemberProfileView.from(member))
                 .content(saved.getContent())
                 .createdAt(DateFormatUtil.formatDate(saved.getCreatedAt()))
                 .build();
@@ -94,10 +92,7 @@ public class CorrectionCommentService {
         List<CorrectionCommentResponseDTO> content = commentPage.stream()
                 .map(comment -> CorrectionCommentResponseDTO.builder()
                         .commentId(comment.getId())
-                        .memberId(comment.getMember().getId())
-                        .username(comment.getMember().getUsername())
-                        .nickname(comment.getMember().getNickname())
-                        .profileImage(comment.getMember().getProfileImg())
+                        .memberProfileView(MemberProfileView.from(comment.getMember()))
                         .content(comment.getDisplayContent())
                         .createdAt(DateFormatUtil.formatDate(comment.getCreatedAt()))
                         .build())

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -72,7 +72,7 @@ public class CorrectionCommentService {
 
         return CorrectionCommentResponseDTO.builder()
                 .commentId(saved.getId())
-                .memberProfileDTO(MemberProfileDTO.from(member))
+                .memberProfile(MemberProfileDTO.from(member))
                 .content(saved.getContent())
                 .createdAt(DateFormatUtil.formatDate(saved.getCreatedAt()))
                 .build();
@@ -91,7 +91,7 @@ public class CorrectionCommentService {
         List<CorrectionCommentResponseDTO> content = commentPage.stream()
                 .map(comment -> CorrectionCommentResponseDTO.builder()
                         .commentId(comment.getId())
-                        .memberProfileDTO(MemberProfileDTO.from(comment.getMember()))
+                        .memberProfile(MemberProfileDTO.from(comment.getMember()))
                         .content(comment.getDisplayContent())
                         .createdAt(DateFormatUtil.formatDate(comment.getCreatedAt()))
                         .build())

--- a/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/correctioncomment/service/CorrectionCommentService.java
@@ -1,13 +1,12 @@
 package org.lxdproject.lxd.correctioncomment.service;
 
 import lombok.RequiredArgsConstructor;
-import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.guard.PermissionGuard;
-import org.lxdproject.lxd.common.dto.MemberProfileView;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.config.security.SecurityUtil;
@@ -73,7 +72,7 @@ public class CorrectionCommentService {
 
         return CorrectionCommentResponseDTO.builder()
                 .commentId(saved.getId())
-                .memberProfileView(MemberProfileView.from(member))
+                .memberProfileDTO(MemberProfileDTO.from(member))
                 .content(saved.getContent())
                 .createdAt(DateFormatUtil.formatDate(saved.getCreatedAt()))
                 .build();
@@ -92,7 +91,7 @@ public class CorrectionCommentService {
         List<CorrectionCommentResponseDTO> content = commentPage.stream()
                 .map(comment -> CorrectionCommentResponseDTO.builder()
                         .commentId(comment.getId())
-                        .memberProfileView(MemberProfileView.from(comment.getMember()))
+                        .memberProfileDTO(MemberProfileDTO.from(comment.getMember()))
                         .content(comment.getDisplayContent())
                         .createdAt(DateFormatUtil.formatDate(comment.getCreatedAt()))
                         .build())

--- a/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.correctionlike.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 
 public class MemberSavedCorrectionResponseDTO {
@@ -19,7 +20,7 @@ public class MemberSavedCorrectionResponseDTO {
             private String memo;
             private CorrectionInfo correction;
             private DiaryInfo diary;
-            private MemberInfo member;
+            private MemberProfileDTO memberProfile;
 
             @Getter
             @Builder

--- a/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
@@ -41,6 +41,7 @@ public class MemberSavedCorrectionResponseDTO {
                 private String diaryTitle;
                 private String diaryCreatedAt;
                 private String thumbImg;
+                private Long diaryWriterId;
             }
 
         }

--- a/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
@@ -39,6 +39,7 @@ public class MemberSavedCorrectionResponseDTO {
                 private Long diaryId;
                 private String diaryTitle;
                 private String diaryCreatedAt;
+                private String thumbImg;
             }
 
             @Getter

--- a/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/dto/MemberSavedCorrectionResponseDTO.java
@@ -43,14 +43,6 @@ public class MemberSavedCorrectionResponseDTO {
                 private String thumbImg;
             }
 
-            @Getter
-            @Builder
-            public static class MemberInfo {
-                private Long memberId;
-                private String userId;
-                private String nickname;
-                private String profileImageUrl;
-            }
         }
     }
 

--- a/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
@@ -138,6 +138,7 @@ public class MemberSavedCorrectionService {
                         .diaryId(diary.getId())
                         .diaryTitle(diary.getTitle())
                         .diaryCreatedAt(DateFormatUtil.formatDate(diary.getCreatedAt()))
+                        .thumbImg(diary.getThumbImg())
                         .build())
                 .member(MemberSavedCorrectionResponseDTO.SavedListResponseDTO.SavedCorrectionItem.MemberInfo.builder()
                         .memberId(member.getId())

--- a/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
@@ -140,6 +140,7 @@ public class MemberSavedCorrectionService {
                         .diaryTitle(diary.getTitle())
                         .diaryCreatedAt(DateFormatUtil.formatDate(diary.getCreatedAt()))
                         .thumbImg(diary.getThumbImg())
+                        .diaryWriterId(diary.getMember().getId())
                         .build())
                 .memberProfile(MemberProfileDTO.from(member))
                 .build();

--- a/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
+++ b/src/main/java/org/lxdproject/lxd/correctionlike/service/MemberSavedCorrectionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.AuthHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CorrectionHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.correctionlike.dto.MemberSavedCorrectionRequestDTO;
@@ -140,12 +141,7 @@ public class MemberSavedCorrectionService {
                         .diaryCreatedAt(DateFormatUtil.formatDate(diary.getCreatedAt()))
                         .thumbImg(diary.getThumbImg())
                         .build())
-                .member(MemberSavedCorrectionResponseDTO.SavedListResponseDTO.SavedCorrectionItem.MemberInfo.builder()
-                        .memberId(member.getId())
-                        .userId(member.getUsername())
-                        .nickname(member.getNickname())
-                        .profileImageUrl(member.getProfileImg())
-                        .build())
+                .memberProfile(MemberProfileDTO.from(member))
                 .build();
     }
 

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diary.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
@@ -18,10 +19,8 @@ public class DiaryDetailResponseDTO {
     private Visibility visibility;
     private String title;
     private Language language;
-    private Long writerId;
-    private String profileImg;
-    private String writerNickName;
-    private String writerUserName;
+    private MemberProfileDTO memberProfile;
+
     private String createdAt;
     private int commentCount;
     private int likeCount;
@@ -40,10 +39,7 @@ public class DiaryDetailResponseDTO {
                 diary.getVisibility(),
                 diary.getTitle(),
                 diary.getLanguage(),
-                member.getId(),
-                member.getProfileImg(),
-                member.getNickname(),
-                member.getUsername(),
+                MemberProfileDTO.from(member),
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),
@@ -64,10 +60,7 @@ public class DiaryDetailResponseDTO {
                 diary.getVisibility(),
                 diary.getTitle(),
                 diary.getLanguage(),
-                member.getId(),
-                member.getProfileImg(),
-                member.getNickname(),
-                member.getUsername(),
+                MemberProfileDTO.from(member),
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiarySummaryResponseDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Visibility;
 
@@ -11,10 +12,7 @@ import org.lxdproject.lxd.diary.entity.enums.Visibility;
 @AllArgsConstructor
 @Builder
 public class DiarySummaryResponseDTO {
-    private String writerUsername;
-    private String writerNickname;
-    private String writerProfileImg;
-    private Long writerId;
+    private MemberProfileDTO writerMemberProfile;
     private Long diaryId;
     private String createdAt;
     private String title;

--- a/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/MemberDiarySummaryResponseDTO.java
@@ -3,6 +3,7 @@ package org.lxdproject.lxd.diary.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.RelationType;
 import org.lxdproject.lxd.friend.entity.enums.FriendRequestStatus;
@@ -10,9 +11,8 @@ import org.lxdproject.lxd.friend.entity.enums.FriendRequestStatus;
 @Getter
 @Builder
 public class MemberDiarySummaryResponseDTO {
-    private String profileImg;
-    private String username;
-    private String nickname;
+
+    private MemberProfileDTO memberProfile;
     private Long diaryCount;
     private Long friendCount;
     private RelationType relation;

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
@@ -17,4 +17,12 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Diary d SET d.deletedAt = :deletedAt WHERE d.member.id = :memberId")
     void softDeleteDiariesByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    DELETE FROM Diary d 
+    WHERE d.deletedAt IS NOT NULL 
+      AND d.deletedAt <= :threshold
+    """)
+    void deleteDiariesOlderThan30Days(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
@@ -2,10 +2,19 @@ package org.lxdproject.lxd.diary.repository;
 
 import org.lxdproject.lxd.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryRepositoryCustom {
     Optional<Diary> findByIdAndDeletedAtIsNull(Long id);
     Long countByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Diary d SET d.deletedAt = :deletedAt WHERE d.member.id = :memberId")
+    void softDeleteDiariesByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepository.java
@@ -25,4 +25,11 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
       AND d.deletedAt <= :threshold
     """)
     void deleteDiariesOlderThan30Days(@Param("threshold") LocalDateTime threshold);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Diary d SET d.deletedAt = NULL WHERE d.member.id = :memberId AND d.deletedAt = :deletedAt")
+    void recoverDiariesByMemberIdAndDeletedAt(
+            @Param("memberId") Long memberId,
+            @Param("deletedAt") LocalDateTime deletedAt
+    );
 }

--- a/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
+++ b/src/main/java/org/lxdproject/lxd/diary/repository/DiaryRepositoryImpl.java
@@ -196,8 +196,11 @@ public class DiaryRepositoryImpl implements DiaryRepositoryCustom {
     @Override
     public Page<Diary> findExploreDiaries(Long memberId, Language language, Set<Long> friendIds, Pageable pageable) {
 
+        BooleanExpression visibility = VisibilityPredicates.diaryVisibleToOthers(memberId, DIARY, friendIds);
+
         BooleanExpression condition = DIARY.deletedAt.isNull()
-                .and(DIARY.visibility.eq(Visibility.PUBLIC));
+                .and(DIARY.visibility.eq(Visibility.PUBLIC))
+                .and(visibility);
 
         if (language != null) {
             condition = condition.and(DIARY.language.eq(language));

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -6,6 +6,7 @@ import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.guard.PermissionGuard;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.diary.util.DiaryUtil;
@@ -225,10 +226,7 @@ public class DiaryService {
                         .correctionCount(d.getCorrectionCount())
                         .contentPreview(DiaryUtil.generateContentPreview(d.getContent()))
                         .language(d.getLanguage())
-                        .writerUsername(d.getMember().getUsername())
-                        .writerNickname(d.getMember().getNickname())
-                        .writerProfileImg(d.getMember().getProfileImg())
-                        .writerId(d.getMember().getId())
+                        .writerMemberProfile(MemberProfileDTO.from(d.getMember()))
                         .liked(likedSet.contains(d.getId()))
                         .build())
                 .toList();
@@ -270,10 +268,7 @@ public class DiaryService {
                         .correctionCount(d.getCorrectionCount())
                         .contentPreview(DiaryUtil.generateContentPreview(d.getContent()))
                         .language(d.getLanguage())
-                        .writerUsername(d.getMember().getUsername())
-                        .writerNickname(d.getMember().getNickname())
-                        .writerProfileImg(d.getMember().getProfileImg())
-                        .writerId(d.getMember().getId())
+                        .writerMemberProfile(MemberProfileDTO.from(d.getMember()))
                         .liked(likedSet.contains(d.getId()))
                         .build()
                 )
@@ -298,10 +293,7 @@ public class DiaryService {
 
         List<DiarySummaryResponseDTO> dto = diaryPage.getContent().stream()
                 .map(d -> DiarySummaryResponseDTO.builder()
-                        .writerUsername(d.getMember().getUsername())
-                        .writerNickname(d.getMember().getNickname())
-                        .writerProfileImg(d.getMember().getProfileImg())
-                        .writerId(d.getMember().getId())
+                        .writerMemberProfile(MemberProfileDTO.from(d.getMember()))
                         .diaryId(d.getId())
                         .createdAt(DateFormatUtil.formatDate(d.getCreatedAt()))
                         .title(d.getTitle())
@@ -353,9 +345,7 @@ public class DiaryService {
         }
 
         return MemberDiarySummaryResponseDTO.builder()
-                .profileImg(member.getProfileImg())
-                .username(member.getUsername())
-                .nickname(member.getNickname())
+                .memberProfile(MemberProfileDTO.from(member))
                 .nativeLanguage(member.getNativeLanguage())
                 .language(member.getLanguage())
                 .diaryCount(diaryCount)

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -153,7 +153,7 @@ public class DiaryService {
         Diary diary = diaryRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
-        if (!diary.getMember().getId().equals(memberId)) {
+        if (diary.getMember() == null || !diary.getMember().getId().equals(memberId)) {
             throw new DiaryHandler(ErrorStatus.FORBIDDEN_DIARY_UPDATE);
         }
 
@@ -322,6 +322,10 @@ public class DiaryService {
         Member member = memberRepository.findById(targetMemberId)
                                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
+        if (member.isDeleted()) {
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+        }
+
         Long diaryCount = diaryRepository.countByMemberIdAndDeletedAtIsNull(targetMemberId);
 
         Long friendCount = friendRepository.countFriendsByMemberId(targetMemberId);
@@ -358,6 +362,10 @@ public class DiaryService {
     public PageDTO<MyDiarySummaryResponseDTO> getDiariesByMemberId(Long memberId, int page, int size) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.isDeleted()) {
+            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+        }
 
         Long viewerId = SecurityUtil.getCurrentMemberId();
         Set<Long> likedSet = diaryLikeRepository.findLikedDiaryIdSet(viewerId);

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -323,7 +323,7 @@ public class DiaryService {
                                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (member.isDeleted()) {
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.RESOURCE_OWNER_WITHDRAWN);
         }
 
         Long diaryCount = diaryRepository.countByMemberIdAndDeletedAtIsNull(targetMemberId);
@@ -364,7 +364,7 @@ public class DiaryService {
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (member.isDeleted()) {
-            throw new AuthHandler(ErrorStatus.WITHDRAWN_USER);
+            throw new MemberHandler(ErrorStatus.RESOURCE_OWNER_WITHDRAWN);
         }
 
         Long viewerId = SecurityUtil.getCurrentMemberId();

--- a/src/main/java/org/lxdproject/lxd/diarycomment/converter/DiaryCommentConverter.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/converter/DiaryCommentConverter.java
@@ -1,5 +1,6 @@
 package org.lxdproject.lxd.diarycomment.converter;
 
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.diarycomment.dto.DiaryCommentResponseDTO;
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
@@ -22,10 +23,7 @@ public class DiaryCommentConverter {
         return DiaryCommentResponseDTO.Comment.builder()
                 .commentId(comment.getId())
                 .parentId(parentId)
-                .memberId(writer.getId())
-                .username(writer.getUsername())
-                .nickname(writer.getNickname())
-                .profileImage(writer.getProfileImg())
+                .memberProfile(MemberProfileDTO.from(writer))
                 .content(comment.getCommentText())
                 .likeCount(comment.getLikeCount())
                 .isLiked(likedCommentIds.contains(comment.getId()))

--- a/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/dto/DiaryCommentResponseDTO.java
@@ -1,6 +1,7 @@
 package org.lxdproject.lxd.diarycomment.dto;
 
 import lombok.*;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 
 
 import java.time.LocalDateTime;
@@ -10,12 +11,9 @@ import java.util.List;
 @Builder
 public class DiaryCommentResponseDTO {
     private Long commentId; // 댓글 ID
-    private Long memberId; // 작성자 ID
-    private String username;
-    private String nickname;  // 작성자 닉네임
     private Long diaryId;
     private Long parentId; // nullable
-    private String profileImage;
+    private MemberProfileDTO memberProfile;
     private String commentText;
     private int replyCount;
     private int likeCount;
@@ -29,10 +27,7 @@ public class DiaryCommentResponseDTO {
     public static class Comment {
         private Long commentId;
         private Long parentId;
-        private Long memberId;
-        private String username;
-        private String nickname;
-        private String profileImage;
+        private MemberProfileDTO memberProfile;
         private String content;
         private int likeCount;
         private boolean isLiked;

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -19,4 +19,12 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE DiaryComment dc SET dc.deletedAt = :deletedAt WHERE dc.member.id = :memberId")
     void softDeleteDiaryCommentsByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    DELETE FROM DiaryComment dc 
+    WHERE dc.deletedAt IS NOT NULL 
+      AND dc.deletedAt <= :threshold
+    """)
+    void deleteDiaryCommentsOlderThan30Days(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -1,32 +1,17 @@
 package org.lxdproject.lxd.diarycomment.repository;
 
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long>, DiaryCommentRepositoryCustom {
     @Query("SELECT dc.diary.title FROM DiaryComment dc WHERE dc.id = :id AND dc.diary IS NOT NULL")
     Optional<String> findDiaryTitleByCommentId(@Param("id") Long id);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE DiaryComment dc SET dc.deletedAt = :deletedAt WHERE dc.diary.member.id = :memberId")
-    void softDeleteDiaryCommentsByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-    DELETE FROM DiaryComment dc 
-    WHERE dc.deletedAt IS NOT NULL 
-      AND dc.deletedAt <= :threshold
-    """)
-    void deleteDiaryCommentsOlderThan30Days(@Param("threshold") LocalDateTime threshold);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE DiaryComment dc SET dc.deletedAt = NULL WHERE dc.member.id = :memberId AND dc.deletedAt = :deletedAt")

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -17,7 +17,7 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
     Optional<String> findDiaryTitleByCommentId(@Param("id") Long id);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE DiaryComment dc SET dc.deletedAt = :deletedAt WHERE dc.member.id = :memberId")
+    @Query("UPDATE DiaryComment dc SET dc.deletedAt = :deletedAt WHERE dc.diary.member.id = :memberId")
     void softDeleteDiaryCommentsByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -27,4 +27,11 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
       AND dc.deletedAt <= :threshold
     """)
     void deleteDiaryCommentsOlderThan30Days(@Param("threshold") LocalDateTime threshold);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE DiaryComment dc SET dc.deletedAt = NULL WHERE dc.member.id = :memberId AND dc.deletedAt = :deletedAt")
+    void recoverDiaryCommentsByMemberIdAndDeletedAt(
+            @Param("memberId") Long memberId,
+            @Param("deletedAt") LocalDateTime deletedAt
+    );
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -14,9 +14,15 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
     Optional<String> findDiaryTitleByCommentId(@Param("id") Long id);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE DiaryComment dc SET dc.deletedAt = NULL WHERE dc.member.id = :memberId AND dc.deletedAt = :deletedAt")
+    @Query("""
+    UPDATE DiaryComment dc
+    SET dc.deletedAt = NULL
+    WHERE (dc.member.id = :memberId OR dc.diary.member.id = :memberId)
+      AND dc.deletedAt = :deletedAt
+    """)
     void recoverDiaryCommentsByMemberIdAndDeletedAt(
             @Param("memberId") Long memberId,
             @Param("deletedAt") LocalDateTime deletedAt
     );
+
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepository.java
@@ -4,9 +4,11 @@ import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +16,7 @@ public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long
     @Query("SELECT dc.diary.title FROM DiaryComment dc WHERE dc.id = :id AND dc.diary IS NOT NULL")
     Optional<String> findDiaryTitleByCommentId(@Param("id") Long id);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE DiaryComment dc SET dc.deletedAt = :deletedAt WHERE dc.member.id = :memberId")
+    void softDeleteDiaryCommentsByMemberId(@Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryCustom.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/repository/DiaryCommentRepositoryCustom.java
@@ -2,10 +2,13 @@ package org.lxdproject.lxd.diarycomment.repository;
 
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiaryCommentRepositoryCustom {
     List<DiaryComment> findParentComments(Long diaryId, int offset, int size);
     List<DiaryComment> findRepliesByParentIds(List<Long> parentIds);
     Long countParentComments(Long diaryId);
+    void softDeleteMemberComments(Long memberId, LocalDateTime deletedAt);
+    void hardDeleteWithdrawnMemberComments(LocalDateTime threshold);
 }

--- a/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycomment/service/DiaryCommentService.java
@@ -6,6 +6,7 @@ import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.authz.guard.PermissionGuard;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.common.util.DateFormatUtil;
 import org.lxdproject.lxd.config.security.SecurityUtil;
@@ -104,13 +105,11 @@ public class DiaryCommentService {
             notificationService.saveAndPublishNotification(dto);
         }
 
+
         return DiaryCommentResponseDTO.builder()
                 .commentId(saved.getId())
-                .memberId(commentOwner.getId())
-                .username(commentOwner.getUsername())
-                .nickname(commentOwner.getNickname())
+                .memberProfile(MemberProfileDTO.from(commentOwner))
                 .diaryId(diary.getId())
-                .profileImage(commentOwner.getProfileImg())
                 .commentText(saved.getCommentText())
                 .parentId(parent != null ? parent.getId() : null)
                 .replyCount(0)
@@ -155,10 +154,7 @@ public class DiaryCommentService {
                                     .map(reply -> DiaryCommentResponseDTO.Comment.builder()
                                             .commentId(reply.getId())
                                             .parentId(parent.getId())
-                                            .memberId(reply.getMember().getId())
-                                            .username(reply.getMember().getUsername())
-                                            .nickname(reply.getMember().getNickname())
-                                            .profileImage(reply.getMember().getProfileImg())
+                                            .memberProfile(MemberProfileDTO.from(reply.getMember()))
                                             .content(reply.getCommentText())
                                             .likeCount(reply.getLikeCount())
                                             .isLiked(likedCommentIds.contains(reply.getId()))
@@ -171,10 +167,7 @@ public class DiaryCommentService {
                     return DiaryCommentResponseDTO.Comment.builder()
                             .commentId(parent.getId())
                             .parentId(null)
-                            .memberId(parent.getMember().getId())
-                            .username(parent.getMember().getUsername())
-                            .nickname(parent.getMember().getNickname())
-                            .profileImage(parent.getMember().getProfileImg())
+                            .memberProfile(MemberProfileDTO.from(parent.getMember()))
                             .content(parent.getCommentText())
                             .likeCount(parent.getLikeCount())
                             .isLiked(likedCommentIds.contains(parent.getId()))

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/dto/DiaryCommentLikeResponseDTO.java
@@ -2,12 +2,13 @@ package org.lxdproject.lxd.diarycommentlike.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 
 @Getter
 @Builder
 public class DiaryCommentLikeResponseDTO {
     private Long commentId;
-    private Long memberId;
+    private MemberProfileDTO memberProfile;
     private boolean liked;
     private int likeCount;
 }

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/repository/DiaryCommentLikeRepository.java
@@ -1,10 +1,12 @@
 package org.lxdproject.lxd.diarycommentlike.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,5 +19,9 @@ public interface DiaryCommentLikeRepository extends JpaRepository<DiaryCommentLi
     AND l.comment.id IN :commentIds
 """)
     List<Long> findLikedCommentIds(@Param("memberId") Long memberId, @Param("commentIds") List<Long> commentIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "DELETE FROM DiaryCommentLike WHERE member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarycommentlike/service/DiaryCommentLikeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.CommentHandler;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
@@ -56,7 +57,7 @@ public class DiaryCommentLikeService {
 
         return DiaryCommentLikeResponseDTO.builder()
                 .commentId(commentId)
-                .memberId(memberId)
+                .memberProfile(MemberProfileDTO.from(member))
                 .liked(liked)
                 .likeCount(comment.getLikeCount())
                 .build();

--- a/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/dto/DiaryLikeResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 
 public class DiaryLikeResponseDTO {
 
@@ -18,7 +19,7 @@ public class DiaryLikeResponseDTO {
         private Long diaryId;
 
         @Schema(description = "좋아요를 누르거나 해제한 사용자 ID")
-        private Long memberId;
+        private MemberProfileDTO memberProfile;
 
         @Schema(description = "좋아요 상태, 결과가 좋아요 해제되었으면 false / 결과가 좋아요가 생성되었으면 true ")
         private Boolean liked;

--- a/src/main/java/org/lxdproject/lxd/diarylike/entity/DiaryLike.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/entity/DiaryLike.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.lxdproject.lxd.common.entity.BaseEntity;
 import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.member.entity.Member;
 
@@ -13,7 +14,7 @@ import org.lxdproject.lxd.member.entity.Member;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class DiaryLike {
+public class DiaryLike extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/repository/DiaryLikeRepository.java
@@ -4,9 +4,20 @@ import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.diarylike.entity.DiaryLike;
 import org.lxdproject.lxd.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryLikeRepository extends JpaRepository<DiaryLike, Long>, DiaryLikeRepositoryCustom {
     Optional<DiaryLike> findByMemberAndDiary(Member member, Diary diary);
+    List<DiaryLike> findAllByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "DELETE FROM DiaryLike WHERE member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
+++ b/src/main/java/org/lxdproject/lxd/diarylike/service/DiaryLikeService.java
@@ -1,5 +1,6 @@
 package org.lxdproject.lxd.diarylike.service;
 
+import org.lxdproject.lxd.common.dto.MemberProfileDTO;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.DiaryHandler;
@@ -61,7 +62,7 @@ public class DiaryLikeService {
 
         return DiaryLikeResponseDTO.ToggleDiaryLikeResponseDTO.builder()
                 .diaryId(diaryId)
-                .memberId(memberId)
+                .memberProfile(MemberProfileDTO.from(member))
                 .liked(liked)
                 .likedCount(diary.getLikeCount())
                 .build();

--- a/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
@@ -6,11 +6,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 
+import org.lxdproject.lxd.authz.guard.PermissionGuard;
 import org.lxdproject.lxd.common.dto.PageDTO;
 import org.lxdproject.lxd.config.security.SecurityUtil;
 import org.lxdproject.lxd.friend.dto.*;
 import org.lxdproject.lxd.friend.entity.FriendRequest;
-import org.lxdproject.lxd.infra.redis.RedisKeyPrefix;
 import org.lxdproject.lxd.infra.redis.RedisService;
 import org.lxdproject.lxd.member.entity.Member;
 import org.lxdproject.lxd.friend.entity.enums.FriendRequestStatus;
@@ -48,6 +48,8 @@ public class FriendService {
     private final SseEmitterService sseEmitterService;
     private final NotificationRepository notificationRepository;
     private final RedisService redisService;
+
+    private final PermissionGuard permissionGuard;
 
     @Transactional(readOnly = true)
     public FriendListResponseDTO getFriendList(Long memberId, int page, int size) {
@@ -89,6 +91,9 @@ public class FriendService {
 
         Member receiver = memberRepository.findById(receiverId)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 친구 요청이 가능한 지에 대하 인가 검사
+        permissionGuard.canSendFriendRequest(requester, receiver);
 
         boolean alreadyRequested = friendRequestRepository.existsByRequesterAndReceiverAndStatus(
                 requester, receiver, FriendRequestStatus.PENDING);
@@ -137,6 +142,10 @@ public class FriendService {
         // 친구 관계 양방향 저장
         Member requester = request.getRequester();
         Member receiver = request.getReceiver();
+
+        // 친구 요청 수락에 대한 인가 검사
+        permissionGuard.canAcceptFriendRequest(requester, receiver);
+
         friendRepository.saveFriendship(requester, receiver);
 
         // 친구 요청 알림 삭제
@@ -177,6 +186,8 @@ public class FriendService {
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Member target = memberRepository.findById(friendId)
                 .orElseThrow(() -> new FriendHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        permissionGuard.canDeleteFriend(current, target);
 
         boolean exists = friendRepository.areFriends(currentMemberId, friendId);
         if (!exists) {

--- a/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
+++ b/src/main/java/org/lxdproject/lxd/friend/service/FriendService.java
@@ -4,6 +4,7 @@ package org.lxdproject.lxd.friend.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.lxdproject.lxd.apiPayload.code.exception.handler.FriendHandler;
+import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 
 import org.lxdproject.lxd.authz.guard.PermissionGuard;
@@ -54,6 +55,8 @@ public class FriendService {
     @Transactional(readOnly = true)
     public FriendListResponseDTO getFriendList(Long memberId, int page, int size) {
         Member member = findMemberById(memberId);
+
+        permissionGuard.canViewFriendList(member);
 
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Member> friendsPage = getFriends(memberId, pageable);

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -72,7 +72,7 @@ public interface MemberApi {
     @DeleteMapping(value = "/profile-image")
     ApiResponse<String> deleteProfileImage();
 
-    @Operation(summary = "회원 랕퇴 API", description = "계정을 soft delete 한 후 일정 기간 후 hard delete을 진행합니다.", responses = {
+    @Operation(summary = "회원 탈퇴 API", description = "계정을 soft delete 한 후 일정 기간 후 hard delete을 진행합니다.", responses = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러")

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberApi.java
@@ -71,4 +71,12 @@ public interface MemberApi {
     })
     @DeleteMapping(value = "/profile-image")
     ApiResponse<String> deleteProfileImage();
+
+    @Operation(summary = "회원 랕퇴 API", description = "계정을 soft delete 한 후 일정 기간 후 hard delete을 진행합니다.", responses = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러")
+    })
+    @PatchMapping(value = "/status")
+    ApiResponse<String> deleteMember();
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -82,4 +82,10 @@ public class MemberController implements MemberApi {
         memberService.deleteProfileImage();
         return ApiResponse.onSuccess("프로필 이미지가 삭제되었습니다.");
     }
+
+    @Override
+    public ApiResponse<String> deleteMember() {
+        memberService.deleteMember();
+        return ApiResponse.onSuccess("회원이 탈퇴되었습니다.");
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
+++ b/src/main/java/org/lxdproject/lxd/member/controller/MemberController.java
@@ -85,7 +85,8 @@ public class MemberController implements MemberApi {
 
     @Override
     public ApiResponse<String> deleteMember() {
-        memberService.deleteMember();
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        memberService.deleteMember(memberId);
         return ApiResponse.onSuccess("회원이 탈퇴되었습니다.");
     }
 }

--- a/src/main/java/org/lxdproject/lxd/member/entity/Member.java
+++ b/src/main/java/org/lxdproject/lxd/member/entity/Member.java
@@ -23,7 +23,7 @@ import java.util.List;
 @AllArgsConstructor
 @DynamicUpdate
 @DynamicInsert
-//@Where(clause = "deleted_at IS NULL")
+@Where(clause = "is_purged = false")
 public class Member extends BaseEntity {
 
     // 고유번호
@@ -89,6 +89,11 @@ public class Member extends BaseEntity {
     // 알림 설정 여부
     @Column(name = "is_alarm_agreed", nullable = false)
     private Boolean isAlarmAgreed;
+
+    // 탈퇴 후 30일이 지나 완전히 삭제된 회원 여부
+    // true면 시스템 내 모든 조회에서 제외됨 (@Where 조건에 사용)
+    @Column(name = "is_purged", nullable = false)
+    private Boolean isPurged = false;
 
     // 일기 연관관계 설정
     @OneToMany(mappedBy = "member")

--- a/src/main/java/org/lxdproject/lxd/member/entity/Member.java
+++ b/src/main/java/org/lxdproject/lxd/member/entity/Member.java
@@ -23,7 +23,7 @@ import java.util.List;
 @AllArgsConstructor
 @DynamicUpdate
 @DynamicInsert
-@Where(clause = "deleted_at IS NULL")
+//@Where(clause = "deleted_at IS NULL")
 public class Member extends BaseEntity {
 
     // 고유번호

--- a/src/main/java/org/lxdproject/lxd/member/entity/Member.java
+++ b/src/main/java/org/lxdproject/lxd/member/entity/Member.java
@@ -93,6 +93,7 @@ public class Member extends BaseEntity {
     // 탈퇴 후 30일이 지나 완전히 삭제된 회원 여부
     // true면 시스템 내 모든 조회에서 제외됨 (@Where 조건에 사용)
     @Column(name = "is_purged", nullable = false)
+    @Builder.Default
     private Boolean isPurged = false;
 
     // 일기 연관관계 설정

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -21,8 +21,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     @Query("""
     UPDATE Member m
     SET m.isPurged = true,
-        m.nickname = null,
-        m.email = null
+        m.nickname = CONCAT('deleted_', m.id),
+        m.email = CONCAT('deleted_', m.id, '@deleted.local')
     WHERE m.deletedAt IS NOT NULL
       AND m.deletedAt <= :threshold
       AND m.isPurged = false

--- a/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
+++ b/src/main/java/org/lxdproject/lxd/member/repository/MemberRepository.java
@@ -1,13 +1,13 @@
 package org.lxdproject.lxd.member.repository;
 
-import org.lxdproject.lxd.friend.dto.FriendSearchResponseDTO;
 import org.lxdproject.lxd.member.entity.Member;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.Set;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
@@ -16,4 +16,17 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     Boolean existsByUsername(String username);
 
     Optional<Member> findByEmail(String email);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    UPDATE Member m
+    SET m.isPurged = true,
+        m.nickname = null,
+        m.email = null
+    WHERE m.deletedAt IS NOT NULL
+      AND m.deletedAt <= :threshold
+      AND m.isPurged = false
+    """)
+    void deleteMembersOlderThan30Days(@Param("threshold") LocalDateTime threshold);
+
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -5,13 +5,9 @@ import org.lxdproject.lxd.apiPayload.code.exception.handler.MemberHandler;
 import org.lxdproject.lxd.apiPayload.code.status.ErrorStatus;
 import org.lxdproject.lxd.common.entity.enums.ImageDir;
 import org.lxdproject.lxd.common.service.ImageService;
-import org.lxdproject.lxd.diary.entity.Diary;
 import org.lxdproject.lxd.diary.repository.DiaryRepository;
-import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
 import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
-import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
 import org.lxdproject.lxd.diarycommentlike.repository.DiaryCommentLikeRepository;
-import org.lxdproject.lxd.diarylike.entity.DiaryLike;
 import org.lxdproject.lxd.diarylike.repository.DiaryLikeRepository;
 import org.lxdproject.lxd.infra.storage.S3FileService;
 import org.lxdproject.lxd.config.security.SecurityUtil;
@@ -25,9 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -219,7 +213,14 @@ public class MemberService {
 
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
 
+        // 30일이 지난 회원의 isPurged 값을 true로 만들고
+        // nickname/email의 unique 조건을 피하기 위해 null 값으로 채워주기
+        memberRepository.deleteMembersOlderThan30Days(threshold);
+
+        // 탈퇴자의 댓글 모두 hard delete
         diaryCommentRepository.deleteDiaryCommentsOlderThan30Days(threshold);
+
+        // 탈퇴자의 일기 모두 hard delete
         diaryRepository.deleteDiariesOlderThan30Days(threshold);
 
 

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -205,7 +206,21 @@ public class MemberService {
         // 일기 댓글 soft delete
         diaryCommentRepository.softDeleteDiaryCommentsByMemberId(memberId, deletedAt);
 
-        // 해당 일기,댓글 및 각 좋아요는 스케쥴러로 hard delete
+        // 해당 일기 좋아요는 hard delete
+        diaryLikeRepository.deleteAllByMemberId(memberId);
+
+        // 해당 일기 댓글 좋아요는 hard delete
+        diaryCommentLikeRepository.deleteAllByMemberId(memberId);
+
+    }
+
+    @Transactional
+    public void hardDeleteWithdrawnMembers(){
+
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+        diaryRepository.deleteDiariesOlderThan30Days(threshold);
+        diaryCommentRepository.deleteDiaryCommentsOlderThan30Days(threshold);
 
     }
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -171,4 +171,15 @@ public class MemberService {
         member.setProfileImg(null);
     }
 
+    public void deleteMember() {
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+
+        member.softDelete();
+
+
+    }
 }

--- a/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
+++ b/src/main/java/org/lxdproject/lxd/member/service/MemberService.java
@@ -219,8 +219,9 @@ public class MemberService {
 
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
 
-        diaryRepository.deleteDiariesOlderThan30Days(threshold);
         diaryCommentRepository.deleteDiaryCommentsOlderThan30Days(threshold);
+        diaryRepository.deleteDiariesOlderThan30Days(threshold);
+
 
     }
 }

--- a/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
+++ b/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
@@ -2,6 +2,7 @@ package org.lxdproject.lxd.schedular;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.lxdproject.lxd.member.service.MemberService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,9 @@ public class MemberCleanupSchedular {
     private final MemberService memberService;
 
     // 매일 자정에 실행 (cron = "초 분 시 일 월 요일")
-    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "*/10 * * * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "cleanupWithdrawnMembers", lockAtMostFor = "1m")
     public void cleanupWithdrawnMembers() {
         // 일기, 일기 댓글에 대해 hardDelete 수행
         log.info("탈퇴한 지 30일이 지난 회원 스케쥴링 중 ...");

--- a/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
+++ b/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
@@ -1,0 +1,25 @@
+package org.lxdproject.lxd.schedular;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.lxdproject.lxd.member.service.MemberService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class MemberCleanupSchedular {
+
+    private final MemberService memberService;
+
+    // 매일 자정에 실행 (cron = "초 분 시 일 월 요일")
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    public void cleanupWithdrawnMembers() {
+        // 일기, 일기 댓글에 대해 hardDelete 수행
+        log.info("탈퇴한 지 30일이 지난 회원 스케쥴링 중 ...");
+        memberService.hardDeleteWithdrawnMembers();
+
+    }
+
+}

--- a/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
+++ b/src/main/java/org/lxdproject/lxd/schedular/MemberCleanupSchedular.java
@@ -15,8 +15,7 @@ public class MemberCleanupSchedular {
     private final MemberService memberService;
 
     // 매일 자정에 실행 (cron = "초 분 시 일 월 요일")
-    //@Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
-    @Scheduled(cron = "*/10 * * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     @SchedulerLock(name = "cleanupWithdrawnMembers", lockAtMostFor = "1m")
     public void cleanupWithdrawnMembers() {
         // 일기, 일기 댓글에 대해 hardDelete 수행

--- a/src/main/java/org/lxdproject/lxd/schedular/entity/ShedLock.java
+++ b/src/main/java/org/lxdproject/lxd/schedular/entity/ShedLock.java
@@ -1,0 +1,27 @@
+package org.lxdproject.lxd.schedular.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class ShedLock {
+
+    @Id
+    @Column(name = "name", nullable = false, length = 64)
+    private String name;
+
+    @Column(name = "lock_until", nullable = false)
+    private LocalDateTime lockUntil;
+
+    @Column(name = "locked_at", nullable = false)
+    private LocalDateTime lockedAt;
+
+    @Column(name = "locked_by", nullable = false)
+    private String lockedBy;
+
+    // Getter & Setter
+    // 생성자도 필요시 작성
+}

--- a/src/test/java/org/lxdproject/lxd/member/MemberServiceTest.java
+++ b/src/test/java/org/lxdproject/lxd/member/MemberServiceTest.java
@@ -1,0 +1,162 @@
+package org.lxdproject.lxd.member;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.lxdproject.lxd.diary.entity.Diary;
+import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
+import org.lxdproject.lxd.diary.entity.enums.Language;
+import org.lxdproject.lxd.diary.entity.enums.Style;
+import org.lxdproject.lxd.diary.entity.enums.Visibility;
+import org.lxdproject.lxd.diary.repository.DiaryRepository;
+import org.lxdproject.lxd.diarycomment.entity.DiaryComment;
+import org.lxdproject.lxd.diarycomment.repository.DiaryCommentRepository;
+import org.lxdproject.lxd.diarycommentlike.entity.DiaryCommentLike;
+import org.lxdproject.lxd.diarycommentlike.repository.DiaryCommentLikeRepository;
+import org.lxdproject.lxd.diarylike.entity.DiaryLike;
+import org.lxdproject.lxd.diarylike.repository.DiaryLikeRepository;
+import org.lxdproject.lxd.member.entity.Member;
+import org.lxdproject.lxd.member.entity.enums.LoginType;
+import org.lxdproject.lxd.member.entity.enums.Role;
+import org.lxdproject.lxd.member.entity.enums.Status;
+import org.lxdproject.lxd.member.repository.MemberRepository;
+import org.lxdproject.lxd.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class MemberServiceTest {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private DiaryRepository diaryRepository;
+    @Autowired private DiaryCommentRepository diaryCommentRepository;
+    @Autowired private DiaryLikeRepository diaryLikeRepository;
+    @Autowired private DiaryCommentLikeRepository diaryCommentLikeRepository;
+    @Autowired private MemberService memberService;
+
+    @Test
+    @DisplayName("탈퇴 후 30일 이전의 회원은 soft delete, 일기/댓글은 soft delete, 좋아요는 hard delete 됩니다")
+    void deleteMember_shouldSoftDeleteMemberAndContents_andHardDeleteLikes() {
+        // [given] Member + Diary + DiaryComment + DiaryLike + DiaryCommentLike
+        Member member = Member.builder()
+                .username("softUser")
+                .password("pw")
+                .email("soft@test.com")
+                .nickname("소프트")
+                .role(Role.USER)
+                .loginType(LoginType.LOCAL)
+                .nativeLanguage(Language.KO)
+                .language(Language.ENG)
+                .systemLanguage(Language.KO)
+                .isPrivacyAgreed(true)
+                .isAlarmAgreed(true)
+                .status(Status.ACTIVE)
+                .build();
+        memberRepository.save(member);
+
+        Diary diary = Diary.builder()
+                .member(member)
+                .title("소프트 일기")
+                .content("내용")
+                .style(Style.FREE)
+                .visibility(Visibility.PUBLIC)
+                .commentPermission(CommentPermission.ALL)
+                .language(Language.KO)
+                .build();
+        diaryRepository.save(diary);
+
+        DiaryComment comment = DiaryComment.builder()
+                .member(member)
+                .diary(diary)
+                .commentText("소프트 댓글")
+                .build();
+        diaryCommentRepository.save(comment);
+
+        DiaryLike diaryLike = DiaryLike.builder()
+                .member(member)
+                .diary(diary)
+                .build();
+        diaryLikeRepository.save(diaryLike);
+
+        DiaryCommentLike commentLike = DiaryCommentLike.builder()
+                .member(member)
+                .comment(comment)
+                .build();
+        diaryCommentLikeRepository.save(commentLike);
+
+        // [when] 탈퇴 처리 (deleteMember는 soft + like hard delete)
+        memberService.deleteMember(member.getId());
+
+        // [then] member/diary/comment는 soft delete (deletedAt != null)
+        Member withdrawn = memberRepository.findById(member.getId()).orElseThrow();
+        Diary withdrawnDiary = diaryRepository.findById(diary.getId()).orElseThrow();
+        DiaryComment withdrawnComment = diaryCommentRepository.findById(comment.getId()).orElseThrow();
+
+        assertThat(withdrawn.getDeletedAt()).isNotNull();
+        assertThat(withdrawnDiary.getDeletedAt()).isNotNull();
+        assertThat(withdrawnComment.getDeletedAt()).isNotNull();
+
+        // [then] 좋아요는 hard delete (repo 조회 시 존재하지 않아야 함)
+        assertThat(diaryLikeRepository.findById(diaryLike.getId())).isEmpty();
+        assertThat(diaryCommentLikeRepository.findById(commentLike.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 30일 지난 회원, 일기, 댓글이 hard delete 됩니다")
+    void hardDeleteWithdrawnMembers_shouldRemoveOldData() {
+        // [given] Member + Diary + DiaryComment
+        Member member = Member.builder()
+                .username("testUser")
+                .password("encodedPw")
+                .email("test@test.com")
+                .nickname("테스터")
+                .role(Role.USER)
+                .loginType(LoginType.LOCAL)
+                .nativeLanguage(Language.KO)
+                .language(Language.ENG)
+                .systemLanguage(Language.KO)
+                .isPrivacyAgreed(true)
+                .isAlarmAgreed(false)
+                .status(Status.ACTIVE)
+                .build();
+        memberRepository.save(member);
+
+        Diary diary = Diary.builder()
+                .member(member)
+                .title("테스트 일기")
+                .content("내용입니다")
+                .style(Style.FREE)
+                .visibility(Visibility.PUBLIC)
+                .commentPermission(CommentPermission.ALL)
+                .language(Language.KO)
+                .build();
+        diaryRepository.save(diary);
+
+        DiaryComment comment = DiaryComment.builder()
+                .member(member)
+                .diary(diary)
+                .commentText("댓글입니다")
+                .build();
+        diaryCommentRepository.save(comment);
+
+        // soft delete 시점을 31일 전 수정
+        LocalDateTime deletedAt = LocalDateTime.now().minusDays(31);
+        member.softDelete(deletedAt);
+        diary.softDelete(deletedAt);
+        comment.softDelete(deletedAt);
+
+        // [when] hard delete 실행
+        memberService.hardDeleteWithdrawnMembers();
+
+        // [then] 데이터가 완전히 삭제되었는지 검증
+        assertThat(memberRepository.findById(member.getId())).isEmpty();
+        assertThat(diaryRepository.findById(diary.getId())).isEmpty();
+        assertThat(diaryCommentRepository.findById(comment.getId())).isEmpty();
+    }
+
+}


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #267 

## ✏️ Summary
회원 탈퇴 및 관련 기능 구현

## 📝 Changes
- 기존 로그인 로직에서 CustomUserDetails 및 CustomUserDetailsService를 사용하는 로직으로 변경
- withDrawnAccountFilter 생성으로 탈퇴한 사용자는 접근 불가능하게 조치(/auth/recover 제외)
- 로그아웃 시 SecurityContextHolder 초기화
- 회원 탈퇴 시 관련 일기, 댓글, 좋아요 등을 삭제(bulk 연산으로 한꺼번에 deleteAt 업데이트)
- 계정 복구 API 구현 -> 탈퇴한 사용자만 접근 가능하며 30일 전에 호출 시, soft delete 된 데이터 복구
- ShedLock을 사용해서 스케쥴러가 중복 실행되지 않도록 구현
- 교정/교정 댓글에 MemberProfileView 사용으로 변경


## 🔧 개선해야할 점
- 탈퇴 로직 개선 필요
- 교정/교정 댓글 뿐만 아니라 일기 댓글에도 MemberProfileView 적용이 필요
- ShedLock으로 스케쥴러 중복 실행은 막았지만 중단 시, 스케쥴러가 재동작하는 로직이 필요
- 탈퇴 과정 및 복구 처리를 어떻게 처리하면 되는지 프론트엔드에게 전달할 API 명세서 작성 필요



## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
