### PR TITLE
[FIX] 일기 수정 후 내용을 diffHtml로 반환하지 않는 버그 해결

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryApi.java
@@ -122,7 +122,7 @@ public interface DiaryApi {
     })
     ApiResponse<DiaryDetailResponseDTO> updateDiary(
             @PathVariable Long diaryId,
-            @Valid @RequestBody DiaryUpdateDTO request
+            @Valid @RequestBody DiaryUpdateRequestDTO request
     );
 
     @GetMapping("/stats")

--- a/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
+++ b/src/main/java/org/lxdproject/lxd/diary/controller/DiaryController.java
@@ -71,7 +71,7 @@ public class DiaryController implements DiaryApi{
     @Override
     public ApiResponse<DiaryDetailResponseDTO> updateDiary(
             @PathVariable("diaryId") Long diaryId,
-            @Valid @RequestBody DiaryUpdateDTO request
+            @Valid @RequestBody DiaryUpdateRequestDTO request
     ) {
         DiaryDetailResponseDTO response = diaryService.updateDiary(diaryId, request);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -20,7 +20,6 @@ public class DiaryDetailResponseDTO {
     private String title;
     private Language language;
     private MemberProfileDTO memberProfile;
-
     private String createdAt;
     private int commentCount;
     private int likeCount;
@@ -29,9 +28,9 @@ public class DiaryDetailResponseDTO {
     private String diffHtml;
     private CommentPermission commentPermission;
     private String thumbnail;
+    private Boolean isLiked;
 
-    // 일반 조회용
-    public static DiaryDetailResponseDTO from(Diary diary) {
+    public static DiaryDetailResponseDTO from(Diary diary, String diffHtml, boolean liked) {
         Member member = diary.getMember();
 
         return new DiaryDetailResponseDTO(
@@ -43,32 +42,12 @@ public class DiaryDetailResponseDTO {
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),
-                diary.getCorrectionCount(),
-                diary.getContent(),
-                null, // diffHtml은 null 처리
-                diary.getCommentPermission(),
-                diary.getThumbImg()
-        );
-    }
-
-    // diff 결과를 포함한 응답 생성용
-    public static DiaryDetailResponseDTO fromWithDiff(Diary diary, String diffHtml) {
-        Member member = diary.getMember();
-
-        return new DiaryDetailResponseDTO(
-                diary.getId(),
-                diary.getVisibility(),
-                diary.getTitle(),
-                diary.getLanguage(),
-                MemberProfileDTO.from(member),
-                DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
-                diary.getLikeCount(),
-                diary.getCorrectionCount(),
                 diary.getContent(),
-                diffHtml, // diff 결과 포함
+                diffHtml,
                 diary.getCommentPermission(),
-                diary.getThumbImg()
+                diary.getThumbImg(),
+                liked
         );
     }
 }

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryDetailResponseDTO.java
@@ -18,33 +18,31 @@ public class DiaryDetailResponseDTO {
     private Long diaryId;
     private Visibility visibility;
     private String title;
+    private String content; // 마지막으로 수정된 일기 내용
     private Language language;
     private MemberProfileDTO memberProfile;
     private String createdAt;
     private int commentCount;
     private int likeCount;
     private int correctCount;
-    private String content;
-    private String diffHtml;
     private CommentPermission commentPermission;
     private String thumbnail;
     private Boolean isLiked;
 
-    public static DiaryDetailResponseDTO from(Diary diary, String diffHtml, boolean liked) {
+    public static DiaryDetailResponseDTO from(Diary diary, boolean liked) {
         Member member = diary.getMember();
 
         return new DiaryDetailResponseDTO(
                 diary.getId(),
                 diary.getVisibility(),
                 diary.getTitle(),
+                diary.getModifiedContent(),
                 diary.getLanguage(),
                 MemberProfileDTO.from(member),
                 DateFormatUtil.formatDate(diary.getCreatedAt()),
                 diary.getCommentCount(),
                 diary.getLikeCount(),
-                diary.getCommentCount(),
-                diary.getContent(),
-                diffHtml,
+                diary.getCorrectionCount(),
                 diary.getCommentPermission(),
                 diary.getThumbImg(),
                 liked

--- a/src/main/java/org/lxdproject/lxd/diary/dto/DiaryUpdateRequestDTO.java
+++ b/src/main/java/org/lxdproject/lxd/diary/dto/DiaryUpdateRequestDTO.java
@@ -10,7 +10,7 @@ import org.lxdproject.lxd.validation.annotation.MaxImageCount;
 
 @Getter
 @Setter
-public class DiaryUpdateDTO {
+public class DiaryUpdateRequestDTO {
     @NotBlank(message = "제목을 작성해주세요.")
     private String title;
     @NotBlank(message = "내용을 작성해주세요.")

--- a/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
+++ b/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import jakarta.persistence.Id;
 
 import org.lxdproject.lxd.common.entity.BaseEntity;
-import org.lxdproject.lxd.diary.dto.DiaryUpdateDTO;
+import org.lxdproject.lxd.diary.dto.DiaryUpdateRequestDTO;
 import org.lxdproject.lxd.diary.entity.enums.CommentPermission;
 import org.lxdproject.lxd.diary.entity.enums.Language;
 import org.lxdproject.lxd.diary.entity.enums.Style;
@@ -79,7 +79,7 @@ public class Diary extends BaseEntity {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiaryLike> likes = new ArrayList<>();
 
-    public void update(DiaryUpdateDTO dto, String diffHtmlContent) {
+    public void update(DiaryUpdateRequestDTO dto, String diffHtmlContent) {
         this.title = dto.getTitle();
         this.modifiedContent = diffHtmlContent;
         this.visibility = dto.getVisibility();

--- a/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
+++ b/src/main/java/org/lxdproject/lxd/diary/entity/Diary.java
@@ -40,6 +40,9 @@ public class Diary extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @Column(columnDefinition = "TEXT")
+    private String modifiedContent;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @NotNull
@@ -76,9 +79,9 @@ public class Diary extends BaseEntity {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiaryLike> likes = new ArrayList<>();
 
-    public void update(DiaryUpdateDTO dto) {
+    public void update(DiaryUpdateDTO dto, String diffHtmlContent) {
         this.title = dto.getTitle();
-        this.content = dto.getContent();
+        this.modifiedContent = diffHtmlContent;
         this.visibility = dto.getVisibility();
         this.commentPermission = dto.getCommentPermission();
         this.language = dto.getLanguage();

--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -150,7 +150,7 @@ public class DiaryService {
         );
     }
 
-    public DiaryDetailResponseDTO updateDiary(Long id, DiaryUpdateDTO request) {
+    public DiaryDetailResponseDTO updateDiary(Long id, DiaryUpdateRequestDTO request) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         Diary diary = diaryRepository.findByIdAndDeletedAtIsNull(id)


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #Issue_number를 적어주세요 -->
- closed #277

## ✏️ Summary
<!-- 개요
작성한 코드에 swagger 내용을 추가했는지 점검해주세요! -->
일기 작성시 request로 받은 content를 `원문 내용(content)`와 `수정 내용(modifiedContent)` 필드 모두에 저장
이후 DiaryDetailResponseDTO에서 content를 반환시 `수정 내용(modifiedContent)` 필드fmf 사용

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
diary 엔티티 내에 `수정 내용(modifiedContent)` 필드를 추가함

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
