### PR TITLE
[FIX] 일기 썸네일 이미지 조건 검사에 "" 도 거르도록 조건 추가

### DIFF
--- a/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
+++ b/src/main/java/org/lxdproject/lxd/diary/service/DiaryService.java
@@ -173,7 +173,7 @@ public class DiaryService {
             throw new DiaryHandler(ErrorStatus.FORBIDDEN_DIARY_UPDATE);
         }
 
-        if (diary.getThumbImg() != null && !diary.getThumbImg().equals(request.getThumbImg())) {
+        if (diary.getThumbImg() != null && !diary.getThumbImg().isBlank() && !diary.getThumbImg().equals(request.getThumbImg())) {
             s3FileService.deleteImage(diary.getThumbImg());
         }
 


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #303 

## ✏️ Summary
일기 수정 시, 일기 썸네일을 가져올 때 현재 DB에 모든 썸네일 이미지가 비어있으면 null 아닌 ""로 저장되어있음을 확인됨
따라서 썸네일을 가져올 때 null 조건에 더해 isBlank 조건을 더해 해당 오류를 피하고자 함

## 📝 Changes
`diary.getThumbImg() != null ` 을 `diary.getThumbImg() != null && !diary.getThumbImg().isBlank()`로 조건 변경


## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot

<img width="1124" height="146" alt="image" src="https://github.com/user-attachments/assets/5b9ec57c-e98a-4559-99c5-27a1aa25954f" />
-> null 로 저장 안 되어 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 일기 업데이트 시 썸네일 처리 로직이 개선되었습니다. 이제 실제로 변경된 썸네일만 선택적으로 삭제되어 불필요한 파일 삭제가 방지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->