### PR TITLE
[CI/CD] 개발/배포 서버 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,9 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |
+            STACK_FILE=~/deploy/docker-compose.yml
+
+            # 1) env 파일 생성
             cat <<EOF > ~/deploy/.env
             DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
             DOCKER_REPO=${{ secrets.DOCKER_REPO }}
@@ -106,12 +109,27 @@ jobs:
             URLS_FRONTEND=${{ secrets.URLS_FRONTEND }}
             URLS_BACKEND=${{ secrets.URLS_BACKEND }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            DISCORD_ERROR_WEBHOOK_URL=${{ secrets.DISCORD_ERROR_WEBHOOK_URL }}
+            DISCORD_ERROR_WEBHOOK_URL=${{ secrets.DISCORD_ERROR_WEBHOOK_URL }} 
             EOF
-            
-            sudo docker compose -f ~/deploy/docker-compose.yml down
-            sudo docker compose -f ~/deploy/docker-compose.yml pull --ignore-pull-failures
-            sudo docker compose -f ~/deploy/docker-compose.yml up -d --force-recreate
+
+            # 2) 업데이트 할 서비스명
+            SERVICE="app-dev"
+            echo "Deploy target service: $SERVICE"
+
+            # 3) 업데이트할 서비스만 새 이미지로 교체
+            sudo docker compose -f "$STACK_FILE" pull "$SERVICE" --ignore-pull-failures
+            sudo docker compose -f "$STACK_FILE" up -d --force-recreate "$SERVICE"
+
+            # 4) 만약 스택 전체가 죽어 있다면(컨테이너 0개) → 전체 스택 복구
+            RUNNING_COUNT=$(sudo docker compose -f "$STACK_FILE" ps -q | wc -l || echo 0)
+
+            if [ "$RUNNING_COUNT" -eq 0 ]; then
+              sudo docker compose -f "$STACK_FILE" up -d
+            else
+              echo "Running containers detected ($RUNNING_COUNT). Skipping full stack up."
+            fi
+
+            # 5) 안 쓰는 이미지 정리
             sudo docker image prune -f
 
 
@@ -130,6 +148,9 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |
+            STACK_FILE=~/deploy/docker-compose.yml
+
+            # 1) env 파일 생성
             cat <<EOF > ~/deploy/.env
             DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
             DOCKER_REPO=${{ secrets.DOCKER_REPO }}
@@ -150,10 +171,25 @@ jobs:
             URLS_FRONTEND=${{ secrets.URLS_FRONTEND }}
             URLS_BACKEND=${{ secrets.URLS_BACKEND }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            DISCORD_ERROR_WEBHOOK_URL=${{ secrets.DISCORD_ERROR_WEBHOOK_URL }}
+            DISCORD_ERROR_WEBHOOK_URL=${{ secrets.DISCORD_ERROR_WEBHOOK_URL }} 
             EOF
 
-            sudo docker compose -f ~/deploy/docker-compose.yml down
-            sudo docker compose -f ~/deploy/docker-compose.yml pull --ignore-pull-failures
-            sudo docker compose -f ~/deploy/docker-compose.yml up -d --force-recreate
+            # 2) 업데이트 할 서비스명
+            SERVICE="app-prod"
+            echo "Deploy target service: $SERVICE"
+
+            # 3) 업데이트할 서비스만 새 이미지로 교체
+            sudo docker compose -f "$STACK_FILE" pull "$SERVICE" --ignore-pull-failures
+            sudo docker compose -f "$STACK_FILE" up -d --force-recreate "$SERVICE"
+
+            # 4) 만약 스택 전체가 죽어 있다면(컨테이너 0개) → 전체 스택 복구
+            RUNNING_COUNT=$(sudo docker compose -f "$STACK_FILE" ps -q | wc -l || echo 0)
+
+            if [ "$RUNNING_COUNT" -eq 0 ]; then
+              sudo docker compose -f "$STACK_FILE" up -d
+            else
+              echo "Running containers detected ($RUNNING_COUNT). Skipping full stack up."
+            fi
+
+            # 5) 안 쓰는 이미지 정리
             sudo docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.8"
 services:
-  app:
+  app-dev:
     image: ${DOCKER_USERNAME}/${DOCKER_REPO}
     pull_policy: always
     ports:
@@ -31,6 +31,39 @@ services:
         condition: service_healthy
     networks:
        - app-network
+    restart: always
+
+  app-prod:
+    image: ${DOCKER_USERNAME}/${DOCKER_REPO}
+    pull_policy: always
+    ports:
+      - "8081:8080"
+    environment:
+      DB_URL: ${DB_URL}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PWD: ${DB_PWD}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      S3_BUCKET: ${S3_BUCKET}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      JWT_ACCESS_EXPIRATION: ${JWT_ACCESS_EXPIRATION}
+      JWT_REFRESH_EXPIRATION: ${JWT_REFRESH_EXPIRATION}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
+      URLS_FRONTEND: ${URLS_FRONTEND}
+      URLS_BACKEND: ${URLS_BACKEND}
+      SPRING_PROFILES_ACTIVE: prod # prod 프로파일 활성화
+      SENTRY_DSN: ${SENTRY_DSN}
+      DISCORD_ERROR_WEBHOOK_URL: ${DISCORD_ERROR_WEBHOOK_URL}
+      hibernate_ddl_auto: update
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - app-network
     restart: always
 
   redis:


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #312 

## ✏️ Summary
지금은 단일 EC2에서 `main` 배포 시엔 개발 서버, `release` 배포 시엔 배포 서버 역할을 하는 구조
여기서 블루–그린 배포를 도입하기 전에 dev/prod를 먼저 분리하려고 함.

한 EC2 안에서 컨테이너만 나눠서 운영 예정
- `app-dev` (8080): 개발용 (`main` 배포 대상)
- `app-prod` (8081): 배포용 (`release` 배포 대상, Nginx가 프록시)


## 📝 Changes
1. docker-compose.yml에 배포용 스프링 서버 추가
2. deploy.yml에 브런치 별 업데이트 할 스프링 서버를 차별화하는 로직 추가
3. (추가로 해야 할 작업) Nginx의 conf 파일에 proxy_pass 경로를 8081로 수정해야함
4. (추가로 해야 할 작업) 메모리 사용량 측정 및 안정장치 추가


## Notice
<img width="592" height="80" alt="image" src="https://github.com/user-attachments/assets/efabf440-d816-4c8d-9784-297c86020490" />

현재 `free -h`로 메모리 확인 결과 Swap memory가 있지만 기본 메모리가 부족한 상황인데
해당 설정대로 스프링 돌려도 괜찮을까?


## 🔎 PR Type

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [x] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

